### PR TITLE
Revert PR - "Android: Actually use a thread for DirectoryInitialization" by JosJuice

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -54,7 +54,7 @@ public final class DirectoryInitialization
     directoryState.setValue(DirectoryInitializationState.INITIALIZING);
 
     // Can take a few seconds to run, so don't block UI thread.
-    new Thread(() -> init(context)).run();
+    ((Runnable) () -> init(context)).run();
   }
 
   private static void init(Context context)


### PR DESCRIPTION
This change introduced in [https://github.com/dolphin-emu/dolphin/pull/10503](https://github.com/dolphin-emu/dolphin/pull/10503) seemed to cause IOS_FS: Failed to rename temporary FST error, usually during the first startup of MMJR2. This commit reverted it to older behavior. However, it´s not the cause of the problem as this error popped up again during testing. This happens when you reinstall the app while keeping the user directory intact, and only once, during the first run. Using threaded DirectoryInitialization is actually faster, so never mind this change.