### PR TITLE
Integrate PR - "HW/Memmap: Refactor Memory to class, move to Core::System." by AdmiralCurtiss

### DIFF
--- a/Source/Core/Common/NandPaths.cpp
+++ b/Source/Core/Common/NandPaths.cpp
@@ -41,6 +41,12 @@ std::string GetTicketFileName(u64 title_id, std::optional<FromWhichRoot> from)
                      static_cast<u32>(title_id >> 32), static_cast<u32>(title_id));
 }
 
+std::string GetV1TicketFileName(u64 title_id, std::optional<FromWhichRoot> from)
+{
+  return fmt::format("{}/ticket/{:08x}/{:08x}.tv1", RootUserPath(from),
+                     static_cast<u32>(title_id >> 32), static_cast<u32>(title_id));
+}
+
 std::string GetTitlePath(u64 title_id, std::optional<FromWhichRoot> from)
 {
   return fmt::format("{}/title/{:08x}/{:08x}", RootUserPath(from), static_cast<u32>(title_id >> 32),

--- a/Source/Core/Common/NandPaths.h
+++ b/Source/Core/Common/NandPaths.h
@@ -26,6 +26,7 @@ std::string RootUserPath(FromWhichRoot from);
 std::string GetImportTitlePath(u64 title_id, std::optional<FromWhichRoot> from = {});
 
 std::string GetTicketFileName(u64 title_id, std::optional<FromWhichRoot> from = {});
+std::string GetV1TicketFileName(u64 title_id, std::optional<FromWhichRoot> from = {});
 std::string GetTitlePath(u64 title_id, std::optional<FromWhichRoot> from = {});
 std::string GetTitleDataPath(u64 title_id, std::optional<FromWhichRoot> from = {});
 std::string GetTitleContentPath(u64 title_id, std::optional<FromWhichRoot> from = {});

--- a/Source/Core/Core/Boot/Boot.cpp
+++ b/Source/Core/Core/Boot/Boot.cpp
@@ -55,6 +55,7 @@ namespace fs = std::filesystem;
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 #include "DiscIO/Enums.h"
 #include "DiscIO/GameModDescriptor.h"
@@ -348,7 +349,10 @@ bool CBoot::DVDRead(const DiscIO::VolumeDisc& disc, u64 dvd_offset, u32 output_a
   std::vector<u8> buffer(length);
   if (!disc.Read(dvd_offset, length, buffer.data(), partition))
     return false;
-  Memory::CopyToEmu(output_address, buffer.data(), length);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyToEmu(output_address, buffer.data(), length);
   return true;
 }
 
@@ -357,7 +361,11 @@ bool CBoot::DVDReadDiscID(const DiscIO::VolumeDisc& disc, u32 output_address)
   std::array<u8, 0x20> buffer;
   if (!disc.Read(0, buffer.size(), buffer.data(), DiscIO::PARTITION_NONE))
     return false;
-  Memory::CopyToEmu(output_address, buffer.data(), buffer.size());
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyToEmu(output_address, buffer.data(), buffer.size());
+  
   // Transition out of the DiscIdNotRead state (which the drive should be in at this point,
   // on the assumption that this is only used for the first read)
   DVDInterface::SetDriveState(DVDInterface::DriveState::ReadyNoReadsMade);
@@ -455,8 +463,10 @@ bool CBoot::Load_BS2(const std::string& boot_rom_filename)
   // copying the initial boot code to 0x81200000 is a hack.
   // For now, HLE the first few instructions and start at 0x81200150
   // to work around this.
-  Memory::CopyToEmu(0x01200000, data.data() + 0x100, 0x700);
-  Memory::CopyToEmu(0x01300000, data.data() + 0x820, 0x1AFE00);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyToEmu(0x01200000, data.data() + 0x100, 0x700);
+  memory.CopyToEmu(0x01300000, data.data() + 0x820, 0x1AFE00);
 
   PowerPC::ppcState.gpr[3] = 0xfff0001f;
   PowerPC::ppcState.gpr[4] = 0x00002030;
@@ -490,10 +500,12 @@ static void CopyDefaultExceptionHandlers()
                                                  0x00000500, 0x00000600, 0x00000700, 0x00000800,
                                                  0x00000900, 0x00000C00, 0x00000D00, 0x00000F00,
                                                  0x00001300, 0x00001400, 0x00001700};
-
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   constexpr u32 RFI_INSTRUCTION = 0x4C000064;
   for (const u32 address : EXCEPTION_HANDLER_ADDRESSES)
-    Memory::Write_U32(RFI_INSTRUCTION, address);
+    memory.Write_U32(RFI_INSTRUCTION, address);
 }
 
 // Third boot step after BootManager and Core. See Call schedule in BootManager.cpp

--- a/Source/Core/Core/Boot/DolReader.cpp
+++ b/Source/Core/Core/Boot/DolReader.cpp
@@ -12,6 +12,7 @@
 #include "Common/Swap.h"
 #include "Core/Boot/AncastTypes.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 DolReader::DolReader(std::vector<u8> buffer) : BootExecutableReader(std::move(buffer))
 {
@@ -116,26 +117,33 @@ bool DolReader::LoadIntoMemory(bool only_in_mem1) const
 
   if (m_is_ancast)
     return LoadAncastIntoMemory();
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   // load all text (code) sections
   for (size_t i = 0; i < m_text_sections.size(); ++i)
+  {
     if (!m_text_sections[i].empty() &&
         !(only_in_mem1 &&
-          m_dolheader.textAddress[i] + m_text_sections[i].size() >= Memory::GetRamSizeReal()))
+           m_dolheader.textAddress[i] + m_text_sections[i].size() >= memory.GetRamSizeReal()))
     {
-      Memory::CopyToEmu(m_dolheader.textAddress[i], m_text_sections[i].data(),
-                        m_text_sections[i].size());
+      memory.CopyToEmu(m_dolheader.textAddress[i], m_text_sections[i].data(),
+                       m_text_sections[i].size());
     }
+  }
 
   // load all data sections
   for (size_t i = 0; i < m_data_sections.size(); ++i)
+  {
     if (!m_data_sections[i].empty() &&
         !(only_in_mem1 &&
-          m_dolheader.dataAddress[i] + m_data_sections[i].size() >= Memory::GetRamSizeReal()))
+          m_dolheader.dataAddress[i] + m_data_sections[i].size() >= memory.GetRamSizeReal()))
     {
-      Memory::CopyToEmu(m_dolheader.dataAddress[i], m_data_sections[i].data(),
-                        m_data_sections[i].size());
+      memory.CopyToEmu(m_dolheader.dataAddress[i], m_data_sections[i].data(),
+                       m_data_sections[i].size());
     }
+  }
 
   return true;
 }
@@ -219,11 +227,14 @@ bool DolReader::LoadAncastIntoMemory() const
                   body_size))
     return false;
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   // Copy the Ancast header to the emu
-  Memory::CopyToEmu(section_address, header, sizeof(EspressoAncastHeader));
+  memory.CopyToEmu(section_address, header, sizeof(EspressoAncastHeader));
 
   // Copy the decrypted body to the emu
-  Memory::CopyToEmu(section_address + sizeof(EspressoAncastHeader), decrypted.data(), body_size);
+  memory.CopyToEmu(section_address + sizeof(EspressoAncastHeader), decrypted.data(), body_size);
 
   return true;
 }

--- a/Source/Core/Core/Boot/ElfReader.cpp
+++ b/Source/Core/Core/Boot/ElfReader.cpp
@@ -14,6 +14,7 @@
 
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
+#include "Core/System.h"
 
 static void bswap(u32& w)
 {
@@ -134,6 +135,9 @@ bool ElfReader::LoadIntoMemory(bool only_in_mem1) const
   }
 
   INFO_LOG_FMT(BOOT, "{} segments:", header->e_phnum);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   // Copy segments into ram.
   for (int i = 0; i < header->e_phnum; i++)
@@ -150,12 +154,12 @@ bool ElfReader::LoadIntoMemory(bool only_in_mem1) const
       u32 srcSize = p->p_filesz;
       u32 dstSize = p->p_memsz;
 
-      if (only_in_mem1 && p->p_vaddr >= Memory::GetRamSizeReal())
+      if (only_in_mem1 && p->p_vaddr >= memory.GetRamSizeReal())
         continue;
 
-      Memory::CopyToEmu(writeAddr, src, srcSize);
+      memory.CopyToEmu(writeAddr, src, srcSize);
       if (srcSize < dstSize)
-        Memory::Memset(writeAddr + srcSize, 0, dstSize - srcSize);  // zero out bss
+        memory.Memset(writeAddr + srcSize, 0, dstSize - srcSize);  // zero out bss
 
       INFO_LOG_FMT(BOOT, "Loadable Segment Copied to {:08x}, size {:08x}", writeAddr, p->p_memsz);
     }

--- a/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoPlayer.cpp
@@ -494,12 +494,14 @@ void FifoPlayer::WriteAllMemoryUpdates()
 
 void FifoPlayer::WriteMemory(const MemoryUpdate& memUpdate)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   u8* mem = nullptr;
 
   if (memUpdate.address & 0x10000000)
-    mem = &Memory::m_pEXRAM[memUpdate.address & Memory::GetExRamMask()];
+    mem = &memory.GetEXRAM()[memUpdate.address & memory.GetExRamMask()];
   else
-    mem = &Memory::m_pRAM[memUpdate.address & Memory::GetRamMask()];
+    mem = &memory.GetRAM()[memUpdate.address & memory.GetRamMask()];
 
   std::copy(memUpdate.data.begin(), memUpdate.data.end(), mem);
 }

--- a/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
+++ b/Source/Core/Core/FifoPlayer/FifoRecorder.cpp
@@ -12,6 +12,7 @@
 
 #include "Core/ConfigManager.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 #include "VideoCommon/OpcodeDecoding.h"
 #include "VideoCommon/XFStructs.h"
@@ -229,8 +230,10 @@ void FifoRecorder::StartRecording(s32 numFrames, CallbackFunc finishedCb)
   //   - Global variables suck
   //   - Multithreading with the above two sucks
   //
-  m_Ram.resize(Memory::GetRamSize());
-  m_ExRam.resize(Memory::GetExRamSize());
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  m_Ram.resize(memory.GetRamSize());
+  m_ExRam.resize(memory.GetExRamSize());
 
   std::fill(m_Ram.begin(), m_Ram.end(), 0);
   std::fill(m_ExRam.begin(), m_ExRam.end(), 0);
@@ -310,17 +313,20 @@ void FifoRecorder::WriteGPCommand(const u8* data, u32 size)
 
 void FifoRecorder::UseMemory(u32 address, u32 size, MemoryUpdate::Type type, bool dynamicUpdate)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   u8* curData;
   u8* newData;
   if (address & 0x10000000)
   {
-    curData = &m_ExRam[address & Memory::GetExRamMask()];
-    newData = &Memory::m_pEXRAM[address & Memory::GetExRamMask()];
+    curData = &m_ExRam[address & memory.GetExRamMask()];
+    newData = &memory.GetEXRAM()[address & memory.GetExRamMask()];
   }
   else
   {
-    curData = &m_Ram[address & Memory::GetRamMask()];
-    newData = &Memory::m_pRAM[address & Memory::GetRamMask()];
+    curData = &m_Ram[address & memory.GetRamMask()];
+    newData = &memory.GetRAM()[address & memory.GetRamMask()];
   }
 
   if (!dynamicUpdate && memcmp(curData, newData, size) != 0)

--- a/Source/Core/Core/HLE/HLE.cpp
+++ b/Source/Core/Core/HLE/HLE.cpp
@@ -19,6 +19,7 @@
 #include "Core/IOS/ES/ES.h"
 #include "Core/PowerPC/PPCSymbolDB.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 namespace HLE
 {
@@ -90,7 +91,9 @@ void PatchFixedFunctions()
   if (!Config::Get(Config::MAIN_ENABLE_CHEATS))
   {
     Patch(0x80001800, "HBReload");
-    Memory::CopyToEmu(0x00001804, "STUBHAXX", 8);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    memory.CopyToEmu(0x00001804, "STUBHAXX", 8);
   }
 
   // Not part of the binary itself, but either we or Gecko OS might insert

--- a/Source/Core/Core/HW/AddressSpace.cpp
+++ b/Source/Core/Core/HW/AddressSpace.cpp
@@ -10,6 +10,7 @@
 #include "Core/HW/DSP.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/MMU.h"
+#include "Core/System.h"
 
 namespace AddressSpace
 {
@@ -92,6 +93,9 @@ struct EffectiveAddressSpaceAccessors : Accessors
 
   bool Matches(u32 haystack_start, const u8* needle_start, std::size_t needle_size) const
   {
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+
     u32 page_base = haystack_start & 0xfffff000;
     u32 offset = haystack_start & 0x0000fff;
     do
@@ -114,7 +118,7 @@ struct EffectiveAddressSpaceAccessors : Accessors
         return false;
       }
 
-      u8* page_ptr = Memory::GetPointer(*page_physical_address);
+      u8* page_ptr = memory.GetPointer(*page_physical_address);
       if (page_ptr == nullptr)
       {
         return false;
@@ -417,9 +421,12 @@ Accessors* GetAccessors(Type address_space)
 
 void Init()
 {
-  s_mem1_address_space_accessors = {&Memory::m_pRAM, Memory::GetRamSizeReal()};
-  s_mem2_address_space_accessors = {&Memory::m_pEXRAM, Memory::GetExRamSizeReal()};
-  s_fake_address_space_accessors = {&Memory::m_pFakeVMEM, Memory::GetFakeVMemSize()};
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  s_mem1_address_space_accessors = {&memory.GetRAM(), memory.GetRamSizeReal()};
+  s_mem2_address_space_accessors = {&memory.GetEXRAM(), memory.GetExRamSizeReal()};
+  s_fake_address_space_accessors = {&memory.GetFakeVMEM(), memory.GetFakeVMemSize()};
   s_physical_address_space_accessors_gcn = {{0x00000000, &s_mem1_address_space_accessors}};
   s_physical_address_space_accessors_wii = {{0x00000000, &s_mem1_address_space_accessors},
                                             {0x10000000, &s_mem2_address_space_accessors}};

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AX.h
@@ -19,6 +19,7 @@
 #include "Common/Swap.h"
 #include "Core/HW/DSPHLE/UCodes/UCodes.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace DSP::HLE
 {
@@ -142,8 +143,10 @@ protected:
   template <int Millis, size_t BufCount>
   void InitMixingBuffers(u32 init_addr, const std::array<BufferDesc, BufCount>& buffers)
   {
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
     std::array<u16, 3 * BufCount> init_array;
-    Memory::CopyFromEmuSwapped(init_array.data(), init_addr, sizeof(init_array));
+    memory.CopyFromEmuSwapped(init_array.data(), init_addr, sizeof(init_array));
     for (size_t i = 0; i < BufCount; ++i)
     {
       const BufferDesc& buf = buffers[i];

--- a/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/AXVoice.h
@@ -22,6 +22,7 @@
 #include "Core/HW/DSPHLE/UCodes/AX.h"
 #include "Core/HW/DSPHLE/UCodes/AXStructs.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace DSP::HLE
 {
@@ -101,10 +102,13 @@ bool HasLpf(u32 crc)
 // Read a PB from MRAM/ARAM
 void ReadPB(u32 addr, PB_TYPE& pb, u32 crc)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   if (HasLpf(crc))
   {
     u16* dst = (u16*)&pb;
-    Memory::CopyFromEmuSwapped<u16>(dst, addr, sizeof(pb));
+    memory.CopyFromEmuSwapped<u16>(dst, addr, sizeof(pb));
   }
   else
   {
@@ -116,19 +120,22 @@ void ReadPB(u32 addr, PB_TYPE& pb, u32 crc)
     constexpr size_t lpf_off = offsetof(AXPB, lpf);
     constexpr size_t lc_off = offsetof(AXPB, loop_counter);
 
-    Memory::CopyFromEmuSwapped<u16>((u16*)dst, addr, lpf_off);
+    memory.CopyFromEmuSwapped<u16>((u16*)dst, addr, lpf_off);
     memset(dst + lpf_off, 0, lc_off - lpf_off);
-    Memory::CopyFromEmuSwapped<u16>((u16*)(dst + lc_off), addr + lpf_off, sizeof(pb) - lc_off);
+    memory.CopyFromEmuSwapped<u16>((u16*)(dst + lc_off), addr + lpf_off, sizeof(pb) - lc_off);
   }
 }
 
 // Write a PB back to MRAM/ARAM
 void WritePB(u32 addr, const PB_TYPE& pb, u32 crc)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   if (HasLpf(crc))
   {
     const u16* src = (const u16*)&pb;
-    Memory::CopyToEmuSwapped<u16>(addr, src, sizeof(pb));
+    memory.CopyToEmuSwapped<u16>(addr, src, sizeof(pb));
   }
   else
   {
@@ -140,8 +147,8 @@ void WritePB(u32 addr, const PB_TYPE& pb, u32 crc)
     constexpr size_t lpf_off = offsetof(AXPB, lpf);
     constexpr size_t lc_off = offsetof(AXPB, loop_counter);
 
-    Memory::CopyToEmuSwapped<u16>(addr, (const u16*)src, lpf_off);
-    Memory::CopyToEmuSwapped<u16>(addr + lpf_off, (const u16*)(src + lc_off), sizeof(pb) - lc_off);
+    memory.CopyToEmuSwapped<u16>(addr, (const u16*)src, lpf_off);
+    memory.CopyToEmuSwapped<u16>(addr + lpf_off, (const u16*)(src + lc_off), sizeof(pb) - lc_off);
   }
 }
 

--- a/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
+++ b/Source/Core/Core/HW/DSPHLE/UCodes/UCodes.cpp
@@ -30,6 +30,7 @@
 #include "Core/HW/DSPHLE/UCodes/ROM.h"
 #include "Core/HW/DSPHLE/UCodes/Zelda.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace DSP::HLE
 {
@@ -40,28 +41,37 @@ constexpr bool ExramRead(u32 address)
 
 u8 HLEMemory_Read_U8(u32 address)
 {
-  if (ExramRead(address))
-    return Memory::m_pEXRAM[address & Memory::GetExRamMask()];
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
-  return Memory::m_pRAM[address & Memory::GetRamMask()];
+  if (ExramRead(address))
+    return memory.GetEXRAM()[address & memory.GetExRamMask()];
+
+  return memory.GetRAM()[address & memory.GetRamMask()];
 }
 
 void HLEMemory_Write_U8(u32 address, u8 value)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   if (ExramRead(address))
-    Memory::m_pEXRAM[address & Memory::GetExRamMask()] = value;
+    memory.GetEXRAM()[address & memory.GetExRamMask()] = value;
   else
-    Memory::m_pRAM[address & Memory::GetRamMask()] = value;
+    memory.GetRAM()[address & memory.GetRamMask()] = value;
 }
 
 u16 HLEMemory_Read_U16LE(u32 address)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   u16 value;
 
   if (ExramRead(address))
-    std::memcpy(&value, &Memory::m_pEXRAM[address & Memory::GetExRamMask()], sizeof(u16));
+    std::memcpy(&value, &memory.GetEXRAM()[address & memory.GetExRamMask()], sizeof(u16));
   else
-    std::memcpy(&value, &Memory::m_pRAM[address & Memory::GetRamMask()], sizeof(u16));
+    std::memcpy(&value, &memory.GetRAM()[address & memory.GetRamMask()], sizeof(u16));
 
   return value;
 }
@@ -73,10 +83,13 @@ u16 HLEMemory_Read_U16(u32 address)
 
 void HLEMemory_Write_U16LE(u32 address, u16 value)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   if (ExramRead(address))
-    std::memcpy(&Memory::m_pEXRAM[address & Memory::GetExRamMask()], &value, sizeof(u16));
+    std::memcpy(&memory.GetEXRAM()[address & memory.GetExRamMask()], &value, sizeof(u16));
   else
-    std::memcpy(&Memory::m_pRAM[address & Memory::GetRamMask()], &value, sizeof(u16));
+    std::memcpy(&memory.GetRAM()[address & memory.GetRamMask()], &value, sizeof(u16));
 }
 
 void HLEMemory_Write_U16(u32 address, u16 value)
@@ -86,12 +99,15 @@ void HLEMemory_Write_U16(u32 address, u16 value)
 
 u32 HLEMemory_Read_U32LE(u32 address)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   u32 value;
 
   if (ExramRead(address))
-    std::memcpy(&value, &Memory::m_pEXRAM[address & Memory::GetExRamMask()], sizeof(u32));
+    std::memcpy(&value, &memory.GetEXRAM()[address & memory.GetExRamMask()], sizeof(u32));
   else
-    std::memcpy(&value, &Memory::m_pRAM[address & Memory::GetRamMask()], sizeof(u32));
+    std::memcpy(&value, &memory.GetRAM()[address & memory.GetRamMask()], sizeof(u32));
 
   return value;
 }
@@ -103,10 +119,13 @@ u32 HLEMemory_Read_U32(u32 address)
 
 void HLEMemory_Write_U32LE(u32 address, u32 value)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   if (ExramRead(address))
-    std::memcpy(&Memory::m_pEXRAM[address & Memory::GetExRamMask()], &value, sizeof(u32));
+    std::memcpy(&memory.GetEXRAM()[address & memory.GetExRamMask()], &value, sizeof(u32));
   else
-    std::memcpy(&Memory::m_pRAM[address & Memory::GetRamMask()], &value, sizeof(u32));
+    std::memcpy(&memory.GetRAM()[address & memory.GetRamMask()], &value, sizeof(u32));
 }
 
 void HLEMemory_Write_U32(u32 address, u32 value)
@@ -116,10 +135,13 @@ void HLEMemory_Write_U32(u32 address, u32 value)
 
 void* HLEMemory_Get_Pointer(u32 address)
 {
-  if (ExramRead(address))
-    return &Memory::m_pEXRAM[address & Memory::GetExRamMask()];
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
-  return &Memory::m_pRAM[address & Memory::GetRamMask()];
+  if (ExramRead(address))
+    return &memory.GetEXRAM()[address & memory.GetExRamMask()];
+
+  return &memory.GetRAM()[address & memory.GetRamMask()];
 }
 
 UCodeInterface::UCodeInterface(DSPHLE* dsphle, u32 crc)
@@ -188,7 +210,9 @@ void UCodeInterface::PrepareBootUCode(u32 mail)
 
     if (Config::Get(Config::MAIN_DUMP_UCODE))
     {
-      DSP::DumpDSPCode(Memory::GetPointer(m_next_ucode.iram_mram_addr), m_next_ucode.iram_size,
+      auto& system = Core::System::GetInstance();
+      auto& memory = system.GetMemory();
+      DSP::DumpDSPCode(memory.GetPointer(m_next_ucode.iram_mram_addr), m_next_ucode.iram_size,
                        ector_crc);
     }
 

--- a/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
+++ b/Source/Core/Core/HW/DSPLLE/DSPHost.cpp
@@ -18,6 +18,7 @@
 #include "Core/HW/DSPLLE/DSPSymbols.h"
 #include "Core/HW/Memmap.h"
 #include "Core/Host.h"
+#include "Core/System.h"
 #include "VideoCommon/OnScreenDisplay.h"
 
 // The user of the DSPCore library must supply a few functions so that the
@@ -39,12 +40,16 @@ void WriteHostMemory(u8 value, u32 addr)
 
 void DMAToDSP(u16* dst, u32 addr, u32 size)
 {
-  Memory::CopyFromEmuSwapped(dst, addr, size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyFromEmuSwapped(dst, addr, size);
 }
 
 void DMAFromDSP(const u16* src, u32 addr, u32 size)
 {
-  Memory::CopyToEmuSwapped(addr, src, size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyToEmuSwapped(addr, src, size);
 }
 
 void OSD_AddMessage(std::string str, u32 ms)
@@ -70,7 +75,9 @@ void InterruptRequest()
 
 void CodeLoaded(DSPCore& dsp, u32 addr, size_t size)
 {
-  CodeLoaded(dsp, Memory::GetPointer(addr), size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  CodeLoaded(dsp, memory.GetPointer(addr), size);
 }
 
 void CodeLoaded(DSPCore& dsp, const u8* ptr, size_t size)

--- a/Source/Core/Core/HW/DVD/DVDInterface.cpp
+++ b/Source/Core/Core/HW/DVD/DVDInterface.cpp
@@ -896,15 +896,17 @@ void ExecuteCommand(ReplyType reply_type)
   {
   // Used by both GC and Wii
   case DICommand::Inquiry:
+  {
     // (shuffle2) Taken from my Wii
-    Memory::Write_U32(0x00000002, state.DIMAR);      // Revision level, device code
-    Memory::Write_U32(0x20060526, state.DIMAR + 4);  // Release date
-    Memory::Write_U32(0x41000000, state.DIMAR + 8);  // Version
+    auto& memory = system.GetMemory();
+    memory.Write_U32(0x00000002, state.DIMAR);      // Revision level, device code
+    memory.Write_U32(0x20060526, state.DIMAR + 4);  // Release date
+    memory.Write_U32(0x41000000, state.DIMAR + 8);  // Version
 
     INFO_LOG_FMT(DVDINTERFACE, "DVDLowInquiry (Buffer {:#010x}, {:#x})", state.DIMAR,
                  state.DILENGTH);
     break;
-
+  }
   // GC-only patched drive firmware command, used by libogc
   case DICommand::Unknown55:
     INFO_LOG_FMT(DVDINTERFACE, "SetExtension");
@@ -1024,17 +1026,20 @@ void ExecuteCommand(ReplyType reply_type)
     break;
   // Wii-exclusive
   case DICommand::ReadBCA:
+  {
     WARN_LOG_FMT(DVDINTERFACE, "DVDLowReadDiskBca - supplying dummy data to appease NSMBW");
     DolphinAnalytics::Instance().ReportGameQuirk(GameQuirk::USES_DVD_LOW_READ_DISK_BCA);
     // NSMBW checks that the first 0x33 bytes of the BCA are 0, then it expects a 1.
     // Most (all?) other games have 0x34 0's at the start of the BCA, but don't actually
     // read it.  NSMBW doesn't care about the other 12 bytes (which contain manufacturing data?)
 
+    auto& memory = system.GetMemory();
     // TODO: Read the .bca file that cleanrip generates, if it exists
-    // Memory::CopyToEmu(output_address, bca_data, 0x40);
-    Memory::Memset(state.DIMAR, 0, 0x40);
-    Memory::Write_U8(1, state.DIMAR + 0x33);
+    // memory.CopyToEmu(output_address, bca_data, 0x40);
+    memory.Memset(state.DIMAR, 0, 0x40);
+    memory.Write_U8(1, state.DIMAR + 0x33);
     break;
+  }
   // Wii-exclusive
   case DICommand::RequestDiscStatus:
     ERROR_LOG_FMT(DVDINTERFACE, "DVDLowRequestDiscStatus");

--- a/Source/Core/Core/HW/DVD/DVDThread.cpp
+++ b/Source/Core/Core/HW/DVD/DVDThread.cpp
@@ -391,7 +391,10 @@ static void FinishRead(Core::System& system, u64 id, s64 cycles_late)
   else
   {
     if (request.copy_to_ram)
-      Memory::CopyToEmu(request.output_address, buffer.data(), request.length);
+    {
+      auto& memory = system.GetMemory();
+      memory.CopyToEmu(request.output_address, buffer.data(), request.length);
+    }
 
     interrupt = DVDInterface::DIInterruptType::TCINT;
   }

--- a/Source/Core/Core/HW/EXI/EXI_Device.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_Device.cpp
@@ -15,6 +15,7 @@
 #include "Core/HW/EXI/EXI_DeviceMemoryCard.h"
 #include "Core/HW/EXI/EXI_DeviceMic.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace ExpansionInterface
 {
@@ -47,20 +48,24 @@ void IEXIDevice::ImmReadWrite(u32& data, u32 size)
 
 void IEXIDevice::DMAWrite(u32 address, u32 size)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   while (size--)
   {
-    u8 byte = Memory::Read_U8(address++);
+    u8 byte = memory.Read_U8(address++);
     TransferByte(byte);
   }
 }
 
 void IEXIDevice::DMARead(u32 address, u32 size)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   while (size--)
   {
     u8 byte = 0;
     TransferByte(byte);
-    Memory::Write_U8(byte, address++);
+    memory.Write_U8(byte, address++);
   }
 }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceEthernet.cpp
@@ -19,6 +19,7 @@
 #include "Core/HW/EXI/EXI.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 namespace ExpansionInterface
 {
@@ -233,7 +234,9 @@ void CEXIETHERNET::DMAWrite(u32 addr, u32 size)
   if (transfer.region == transfer.MX && transfer.direction == transfer.WRITE &&
       transfer.address == BBA_WRTXFIFOD)
   {
-    DirectFIFOWrite(Memory::GetPointer(addr), size);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    DirectFIFOWrite(memory.GetPointer(addr), size);
   }
   else
   {
@@ -246,7 +249,9 @@ void CEXIETHERNET::DMAWrite(u32 addr, u32 size)
 void CEXIETHERNET::DMARead(u32 addr, u32 size)
 {
   DEBUG_LOG_FMT(SP1, "DMA read: {:08x} {:x}", addr, size);
-  Memory::CopyToEmu(addr, &mBbaMem[transfer.address], size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyToEmu(addr, &mBbaMem[transfer.address], size);
   transfer.address += size;
 }
 

--- a/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
+++ b/Source/Core/Core/HW/EXI/EXI_DeviceMemoryCard.cpp
@@ -523,7 +523,9 @@ void CEXIMemoryCard::DoState(PointerWrap& p)
 // read all at once instead of single byte at a time as done by IEXIDevice::DMARead
 void CEXIMemoryCard::DMARead(u32 addr, u32 size)
 {
-  m_memory_card->Read(m_address, size, Memory::GetPointer(addr));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  m_memory_card->Read(m_address, size, memory.GetPointer(addr));
 
   if ((m_address + size) % Memcard::BLOCK_SIZE == 0)
   {
@@ -531,7 +533,7 @@ void CEXIMemoryCard::DMARead(u32 addr, u32 size)
   }
 
   // Schedule transfer complete later based on read speed
-  Core::System::GetInstance().GetCoreTiming().ScheduleEvent(
+  system.GetCoreTiming().ScheduleEvent(
       size * (SystemTimers::GetTicksPerSecond() / MC_TRANSFER_RATE_READ),
       s_et_transfer_complete[m_card_slot], static_cast<u64>(m_card_slot));
 }
@@ -540,7 +542,9 @@ void CEXIMemoryCard::DMARead(u32 addr, u32 size)
 // write all at once instead of single byte at a time as done by IEXIDevice::DMAWrite
 void CEXIMemoryCard::DMAWrite(u32 addr, u32 size)
 {
-  m_memory_card->Write(m_address, size, Memory::GetPointer(addr));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  m_memory_card->Write(m_address, size, memory.GetPointer(addr));
 
   if (((m_address + size) % Memcard::BLOCK_SIZE) == 0)
   {
@@ -548,7 +552,7 @@ void CEXIMemoryCard::DMAWrite(u32 addr, u32 size)
   }
 
   // Schedule transfer complete later based on write speed
-  Core::System::GetInstance().GetCoreTiming().ScheduleEvent(
+  system.GetCoreTiming().ScheduleEvent(
       size * (SystemTimers::GetTicksPerSecond() / MC_TRANSFER_RATE_WRITE),
       s_et_transfer_complete[m_card_slot], static_cast<u64>(m_card_slot));
 }

--- a/Source/Core/Core/HW/GPFifo.cpp
+++ b/Source/Core/Core/HW/GPFifo.cpp
@@ -83,9 +83,12 @@ void ResetGatherPipe()
 
 void UpdateGatherPipe()
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   size_t pipe_count = GetGatherPipeCount();
   size_t processed;
-  u8* cur_mem = Memory::GetPointer(ProcessorInterface::Fifo_CPUWritePointer);
+  u8* cur_mem = memory.GetPointer(ProcessorInterface::Fifo_CPUWritePointer);
   for (processed = 0; pipe_count >= GATHER_PIPE_SIZE; processed += GATHER_PIPE_SIZE)
   {
     // copy the GatherPipe
@@ -96,7 +99,7 @@ void UpdateGatherPipe()
     if (ProcessorInterface::Fifo_CPUWritePointer == ProcessorInterface::Fifo_CPUEnd)
     {
       ProcessorInterface::Fifo_CPUWritePointer = ProcessorInterface::Fifo_CPUBase;
-      cur_mem = Memory::GetPointer(ProcessorInterface::Fifo_CPUWritePointer);
+      cur_mem = memory.GetPointer(ProcessorInterface::Fifo_CPUWritePointer);
     }
     else
     {
@@ -104,8 +107,7 @@ void UpdateGatherPipe()
       ProcessorInterface::Fifo_CPUWritePointer += GATHER_PIPE_SIZE;
     }
 
-    auto& system = Core::System::GetInstance();
-    system.GetCommandProcessor().GatherPipeBursted(system);
+      system.GetCommandProcessor().GatherPipeBursted(system);
   }
 
   // move back the spill bytes

--- a/Source/Core/Core/HW/HW.cpp
+++ b/Source/Core/Core/HW/HW.cpp
@@ -33,7 +33,8 @@ namespace HW
 {
 void Init(const Sram* override_sram)
 {
-  Core::System::GetInstance().GetCoreTiming().Init();
+  auto& system = Core::System::GetInstance();
+  system.GetCoreTiming().Init();
   SystemTimers::PreInit();
 
   State::Init();
@@ -45,7 +46,7 @@ void Init(const Sram* override_sram)
   ProcessorInterface::Init();
   ExpansionInterface::Init(override_sram);  // Needs to be initialized before Memory
   HSP::Init();
-  Memory::Init();  // Needs to be initialized before AddressSpace
+  system.GetMemory().Init();  // Needs to be initialized before AddressSpace
   AddressSpace::Init();
   MemoryInterface::Init();
   DSP::Init(Config::Get(Config::MAIN_DSP_HLE));
@@ -63,6 +64,8 @@ void Init(const Sram* override_sram)
 
 void Shutdown()
 {
+  auto& system = Core::System::GetInstance();
+  
   // IOS should always be shut down regardless of bWii because it can be running in GC mode (MIOS).
   IOS::HLE::Shutdown();  // Depends on Memory
   IOS::Shutdown();
@@ -73,19 +76,20 @@ void Shutdown()
   DSP::Shutdown();
   MemoryInterface::Shutdown();
   AddressSpace::Shutdown();
-  Memory::Shutdown();
+  system.GetMemory().Shutdown();
   HSP::Shutdown();
   ExpansionInterface::Shutdown();
   SerialInterface::Shutdown();
   AudioInterface::Shutdown();
 
   State::Shutdown();
-  Core::System::GetInstance().GetCoreTiming().Shutdown();
+  system.GetCoreTiming().Shutdown();
 }
 
 void DoState(PointerWrap& p)
 {
-  Memory::DoState(p);
+  auto& system = Core::System::GetInstance();
+  system.GetMemory().DoState(p);
   p.DoMarker("Memory");
   MemoryInterface::DoState(p);
   p.DoMarker("MemoryInterface");

--- a/Source/Core/Core/HW/Memmap.h
+++ b/Source/Core/Core/HW/Memmap.h
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "Common/CommonTypes.h"
 #include "Common/MathUtil.h"
+#include "Common/MemArena.h"
 #include "Common/Swap.h"
 #include "Core/PowerPC/MMU.h"
 
@@ -20,35 +23,6 @@ class Mapping;
 
 namespace Memory
 {
-// Base is a pointer to the base of the memory map. Yes, some MMU tricks
-// are used to set up a full GC or Wii memory map in process memory.
-// In 64-bit, this might point to "high memory" (above the 32-bit limit),
-// so be sure to load it into a 64-bit register.
-extern u8* physical_base;
-extern u8* logical_base;
-
-// This page table is used for a "soft MMU" implementation when
-// setting up the full memory map in process memory isn't possible.
-extern u8* physical_page_mappings_base;
-extern u8* logical_page_mappings_base;
-
-// The actual memory used for backing the memory map.
-extern u8* m_pRAM;
-extern u8* m_pEXRAM;
-extern u8* m_pL1Cache;
-extern u8* m_pFakeVMEM;
-
-u32 GetRamSizeReal();
-u32 GetRamSize();
-u32 GetRamMask();
-u32 GetFakeVMemSize();
-u32 GetFakeVMemMask();
-u32 GetL1CacheSize();
-u32 GetL1CacheMask();
-u32 GetExRamSizeReal();
-u32 GetExRamSize();
-u32 GetExRamMask();
-
 constexpr u32 MEM1_BASE_ADDR = 0x80000000U;
 constexpr u32 MEM2_BASE_ADDR = 0x90000000U;
 constexpr u32 MEM1_SIZE_RETAIL = 0x01800000U;
@@ -56,62 +30,214 @@ constexpr u32 MEM1_SIZE_GDEV = 0x04000000U;
 constexpr u32 MEM2_SIZE_RETAIL = 0x04000000U;
 constexpr u32 MEM2_SIZE_NDEV = 0x08000000U;
 
-// MMIO mapping object.
-extern std::unique_ptr<MMIO::Mapping> mmio_mapping;
-
-// Init and Shutdown
-bool IsInitialized();
-void Init();
-void Shutdown();
-bool InitFastmemArena();
-void ShutdownFastmemArena();
-void DoState(PointerWrap& p);
-
-void UpdateLogicalMemory(const PowerPC::BatTable& dbat_table);
-
-void Clear();
-
-// Routines to access physically addressed memory, designed for use by
-// emulated hardware outside the CPU. Use "Device_" prefix.
-std::string GetString(u32 em_address, size_t size = 0);
-u8* GetPointer(u32 address);
-u8* GetPointerForRange(u32 address, size_t size);
-void CopyFromEmu(void* data, u32 address, size_t size);
-void CopyToEmu(u32 address, const void* data, size_t size);
-void Memset(u32 address, u8 value, size_t size);
-u8 Read_U8(u32 address);
-u16 Read_U16(u32 address);
-u32 Read_U32(u32 address);
-u64 Read_U64(u32 address);
-void Write_U8(u8 var, u32 address);
-void Write_U16(u16 var, u32 address);
-void Write_U32(u32 var, u32 address);
-void Write_U64(u64 var, u32 address);
-void Write_U32_Swap(u32 var, u32 address);
-void Write_U64_Swap(u64 var, u32 address);
-
-// Templated functions for byteswapped copies.
-template <typename T>
-void CopyFromEmuSwapped(T* data, u32 address, size_t size)
+struct PhysicalMemoryRegion
 {
-  const T* src = reinterpret_cast<T*>(GetPointerForRange(address, size));
+  u8** out_pointer;
+  u32 physical_address;
+  u32 size;
+  enum : u32
+  {
+    ALWAYS = 0,
+    FAKE_VMEM = 1,
+    WII_ONLY = 2,
+  } flags;
+  u32 shm_position;
+  bool active;
+};
 
-  if (src == nullptr)
-    return;
-
-  for (size_t i = 0; i < size / sizeof(T); i++)
-    data[i] = Common::FromBigEndian(src[i]);
-}
-
-template <typename T>
-void CopyToEmuSwapped(u32 address, const T* data, size_t size)
+struct LogicalMemoryView
 {
-  T* dest = reinterpret_cast<T*>(GetPointerForRange(address, size));
+  void* mapped_pointer;
+  u32 mapped_size;
+};
 
-  if (dest == nullptr)
-    return;
+class MemoryManager
+{
+public:
+  MemoryManager();
+  MemoryManager(const MemoryManager& other) = delete;
+  MemoryManager(MemoryManager&& other) = delete;
+  MemoryManager& operator=(const MemoryManager& other) = delete;
+  MemoryManager& operator=(MemoryManager&& other) = delete;
+  ~MemoryManager();
 
-  for (size_t i = 0; i < size / sizeof(T); i++)
-    dest[i] = Common::FromBigEndian(data[i]);
-}
+  u32 GetRamSizeReal() const { return m_ram_size_real; }
+  u32 GetRamSize() const { return m_ram_size; }
+  u32 GetRamMask() const { return m_ram_mask; }
+  u32 GetFakeVMemSize() const { return m_fakevmem_size; }
+  u32 GetFakeVMemMask() const { return m_fakevmem_mask; }
+  u32 GetL1CacheSize() const { return m_l1_cache_size; }
+  u32 GetL1CacheMask() const { return m_l1_cache_mask; }
+  u32 GetExRamSizeReal() const { return m_exram_size_real; }
+  u32 GetExRamSize() const { return m_exram_size; }
+  u32 GetExRamMask() const { return m_exram_mask; }
+
+  u8* GetPhysicalBase() const { return m_physical_base; }
+  u8* GetLogicalBase() const { return m_logical_base; }
+  u8* GetPhysicalPageMappingsBase() const { return m_physical_page_mappings_base; }
+  u8* GetLogicalPageMappingsBase() const { return m_logical_page_mappings_base; }
+
+  // FIXME: these should not return their address, but AddressSpace wants that
+  u8*& GetRAM() { return m_ram; }
+  u8*& GetEXRAM() { return m_exram; }
+  u8* GetL1Cache() { return m_l1_cache; }
+  u8*& GetFakeVMEM() { return m_fake_vmem; }
+
+  MMIO::Mapping* GetMMIOMapping() const { return m_mmio_mapping.get(); }
+
+  // Init and Shutdown
+  bool IsInitialized() const { return m_is_initialized; }
+  void Init();
+  void Shutdown();
+  bool InitFastmemArena();
+  void ShutdownFastmemArena();
+  void DoState(PointerWrap& p);
+
+  void UpdateLogicalMemory(const PowerPC::BatTable& dbat_table);
+
+  void Clear();
+
+  // Routines to access physically addressed memory, designed for use by
+  // emulated hardware outside the CPU. Use "Device_" prefix.
+  std::string GetString(u32 em_address, size_t size = 0);
+  u8* GetPointer(u32 address) const;
+  u8* GetPointerForRange(u32 address, size_t size) const;
+  void CopyFromEmu(void* data, u32 address, size_t size) const;
+  void CopyToEmu(u32 address, const void* data, size_t size);
+  void Memset(u32 address, u8 value, size_t size);
+  u8 Read_U8(u32 address) const;
+  u16 Read_U16(u32 address) const;
+  u32 Read_U32(u32 address) const;
+  u64 Read_U64(u32 address) const;
+  void Write_U8(u8 var, u32 address);
+  void Write_U16(u16 var, u32 address);
+  void Write_U32(u32 var, u32 address);
+  void Write_U64(u64 var, u32 address);
+  void Write_U32_Swap(u32 var, u32 address);
+  void Write_U64_Swap(u64 var, u32 address);
+
+  // Templated functions for byteswapped copies.
+  template <typename T>
+  void CopyFromEmuSwapped(T* data, u32 address, size_t size) const
+  {
+    const T* src = reinterpret_cast<T*>(GetPointerForRange(address, size));
+
+    if (src == nullptr)
+      return;
+
+    for (size_t i = 0; i < size / sizeof(T); i++)
+      data[i] = Common::FromBigEndian(src[i]);
+  }
+
+  template <typename T>
+  void CopyToEmuSwapped(u32 address, const T* data, size_t size)
+  {
+    T* dest = reinterpret_cast<T*>(GetPointerForRange(address, size));
+
+    if (dest == nullptr)
+      return;
+
+    for (size_t i = 0; i < size / sizeof(T); i++)
+      dest[i] = Common::FromBigEndian(data[i]);
+  }
+
+private:
+  // Base is a pointer to the base of the memory map. Yes, some MMU tricks
+  // are used to set up a full GC or Wii memory map in process memory.
+  // In 64-bit, this might point to "high memory" (above the 32-bit limit),
+  // so be sure to load it into a 64-bit register.
+  u8* m_physical_base = nullptr;
+  u8* m_logical_base = nullptr;
+
+  // This page table is used for a "soft MMU" implementation when
+  // setting up the full memory map in process memory isn't possible.
+  u8* m_physical_page_mappings_base = nullptr;
+  u8* m_logical_page_mappings_base = nullptr;
+
+  // The actual memory used for backing the memory map.
+  u8* m_ram;
+  u8* m_exram;
+  u8* m_l1_cache;
+  u8* m_fake_vmem;
+
+  // m_ram_size is the amount allocated by the emulator, whereas m_ram_size_real
+  // is what will be reported in lowmem, and thus used by emulated software.
+  // Note: Writing to lowmem is done by IPL. If using retail IPL, it will
+  // always be set to 24MB.
+  u32 m_ram_size_real;
+  u32 m_ram_size;
+  u32 m_ram_mask;
+  u32 m_fakevmem_size;
+  u32 m_fakevmem_mask;
+  u32 m_l1_cache_size;
+  u32 m_l1_cache_mask;
+  // m_exram_size is the amount allocated by the emulator, whereas m_exram_size_real
+  // is what gets used by emulated software.  If using retail IOS, it will
+  // always be set to 64MB.
+  u32 m_exram_size_real;
+  u32 m_exram_size;
+  u32 m_exram_mask;
+
+  bool m_is_fastmem_arena_initialized = false;
+
+  // STATE_TO_SAVE
+  // Save the Init(), Shutdown() state
+  bool m_is_initialized = false;
+  // END STATE_TO_SAVE
+
+  // MMIO mapping object.
+  std::unique_ptr<MMIO::Mapping> m_mmio_mapping;
+
+  // The MemArena class
+  Common::MemArena m_arena;
+
+  // Dolphin allocates memory to represent four regions:
+  // - 32MB RAM (actually 24MB on hardware), available on GameCube and Wii
+  // - 64MB "EXRAM", RAM only available on Wii
+  // - 32MB FakeVMem, allocated in GameCube mode when MMU support is turned off.
+  //   This is used to approximate the behavior of a common library which pages
+  //   memory to and from the DSP's dedicated RAM. The DSP's RAM (ARAM) isn't
+  //   directly addressable on GameCube.
+  // - 256KB Locked L1, to represent cache lines allocated out of the L1 data
+  //   cache in Locked L1 mode.  Dolphin does not emulate this hardware feature
+  //   accurately; it just pretends there is extra memory at 0xE0000000.
+  //
+  // The 4GB starting at m_physical_base represents access from the CPU
+  // with address translation turned off. (This is only used by the CPU;
+  // other devices, like the GPU, use other rules, approximated by
+  // Memory::GetPointer.) This memory is laid out as follows:
+  // [0x00000000, 0x02000000) - 32MB RAM
+  // [0x02000000, 0x08000000) - Mirrors of 32MB RAM (not handled here)
+  // [0x08000000, 0x0C000000) - EFB "mapping" (not handled here)
+  // [0x0C000000, 0x0E000000) - MMIO etc. (not handled here)
+  // [0x10000000, 0x14000000) - 64MB RAM (Wii-only; slightly slower)
+  // [0x7E000000, 0x80000000) - FakeVMEM
+  // [0xE0000000, 0xE0040000) - 256KB locked L1
+  //
+  // The 4GB starting at m_logical_base represents access from the CPU
+  // with address translation turned on.  This mapping is computed based
+  // on the BAT registers.
+  //
+  // Each of these 4GB regions is followed by 4GB of empty space so overflows
+  // in address computation in the JIT don't access the wrong memory.
+  //
+  // The neighboring mirrors of RAM ([0x02000000, 0x08000000), etc.) exist because
+  // the bus masks off the bits in question for RAM accesses; using them is a
+  // terrible idea because the CPU cache won't handle them correctly, but a
+  // few buggy games (notably Rogue Squadron 2) use them by accident. They
+  // aren't backed by memory mappings because they are used very rarely.
+  //
+  // Dolphin doesn't emulate the difference between cached and uncached access.
+  //
+  // TODO: The actual size of RAM is 24MB; the other 8MB shouldn't be backed by actual memory.
+  // TODO: Do we want to handle the mirrors of the GC RAM?
+  std::array<PhysicalMemoryRegion, 4> m_physical_regions;
+
+  std::vector<LogicalMemoryView> m_logical_mapped_entries;
+
+  std::array<void*, PowerPC::BAT_PAGE_COUNT> m_physical_page_mappings;
+  std::array<void*, PowerPC::BAT_PAGE_COUNT> m_logical_page_mappings;
+
+  void InitMMIO(bool is_wii);
+};
 }  // namespace Memory

--- a/Source/Core/Core/IOS/DI/DI.cpp
+++ b/Source/Core/Core/IOS/DI/DI.cpp
@@ -21,14 +21,25 @@
 #include "Core/HW/WII_IPC.h"
 #include "Core/IOS/ES/ES.h"
 #include "Core/IOS/ES/Formats.h"
+#include "Core/System.h"
 #include "DiscIO/Volume.h"
 
 template <u32 addr>
 class RegisterWrapper
 {
 public:
-  operator u32() const { return Memory::mmio_mapping->Read<u32>(addr); }
-  void operator=(u32 rhs) { Memory::mmio_mapping->Write(addr, rhs); }
+  operator u32() const
+  {
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    return memory.GetMMIOMapping()->Read<u32>(addr);
+  }
+  void operator=(u32 rhs)
+  {
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    memory.GetMMIOMapping()->Write(addr, rhs);
+  }
 };
 static RegisterWrapper<0x0D806000> DISR;
 static RegisterWrapper<0x0D806004> DICVR;
@@ -53,7 +64,7 @@ DIDevice::DIDevice(Kernel& ios, const std::string& device_name) : Device(ios, de
 
 void DIDevice::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
+  Device::DoState(p);
   p.Do(m_commands_to_execute);
   p.Do(m_executing_command);
   p.Do(m_current_partition);
@@ -76,7 +87,9 @@ std::optional<IPCReply> DIDevice::IOCtl(const IOCtlRequest& request)
   // asynchronously. The rest are also treated as async to match this.  Only one command can be
   // executed at a time, so commands are queued until DVDInterface is ready to handle them.
 
-  const u8 command = Memory::Read_U8(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const u8 command = memory.Read_U8(request.buffer_in);
   if (request.request != command)
   {
     WARN_LOG_FMT(IOS_DI,
@@ -128,7 +141,9 @@ std::optional<DIDevice::DIResult> DIDevice::WriteIfFits(const IOCtlRequest& requ
   }
   else
   {
-    Memory::Write_U32(value, request.buffer_out);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    memory.Write_U32(value, request.buffer_out);
     return DIResult::Success;
   }
 }
@@ -152,6 +167,9 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return DIResult::SecurityError;
   }
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   // DVDInterface's ExecuteCommand handles most of the work for most of these.
   // The IOCtl callback is used to generate a reply afterwards.
   switch (static_cast<DIIoctl>(request.request))
@@ -169,7 +187,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return StartDMATransfer(0x20, request);
     // TODO: Include an additional read that happens on Wii discs, or at least
     // emulate its side effect of disabling DTK configuration
-    // if (Memory::Read_U32(request.buffer_out + 24) == 0x5d1c9ea3) { // Wii Magic
+    // if (memory.Read_U32(request.buffer_out + 24) == 0x5d1c9ea3) { // Wii Magic
     //   if (!m_has_read_encryption_info) {
     //     // Read 0x44 (=> 0x60) bytes starting from offset 8 or byte 0x20;
     //     // byte 0x60 is disable hashing and byte 0x61 is disable encryption
@@ -177,8 +195,8 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     // }
   case DIIoctl::DVDLowRead:
   {
-    const u32 length = Memory::Read_U32(request.buffer_in + 4);
-    const u32 position = Memory::Read_U32(request.buffer_in + 8);
+    const u32 length = memory.Read_U32(request.buffer_in + 4);
+    const u32 position = memory.Read_U32(request.buffer_in + 8);
     INFO_LOG_FMT(IOS_DI, "DVDLowRead: offset {:#010x} (byte {:#011x}), length {:#x}", position,
                  static_cast<u64>(position) << 2, length);
     if (m_current_partition == DiscIO::PARTITION_NONE)
@@ -220,7 +238,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return DIResult::BadArgument;
   case DIIoctl::DVDLowReadDvdPhysical:
   {
-    const u8 position = Memory::Read_U8(request.buffer_in + 7);
+    const u8 position = memory.Read_U8(request.buffer_in + 7);
     INFO_LOG_FMT(IOS_DI, "DVDLowReadDvdPhysical: position {:#04x}", position);
     DICMDBUF0 = 0xAD000000 | (position << 8);
     DICMDBUF1 = 0;
@@ -229,7 +247,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowReadDvdCopyright:
   {
-    const u8 position = Memory::Read_U8(request.buffer_in + 7);
+    const u8 position = memory.Read_U8(request.buffer_in + 7);
     INFO_LOG_FMT(IOS_DI, "DVDLowReadDvdCopyright: position {:#04x}", position);
     DICMDBUF0 = 0xAD010000 | (position << 8);
     DICMDBUF1 = 0;
@@ -238,7 +256,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowReadDvdDiscKey:
   {
-    const u8 position = Memory::Read_U8(request.buffer_in + 7);
+    const u8 position = memory.Read_U8(request.buffer_in + 7);
     INFO_LOG_FMT(IOS_DI, "DVDLowReadDvdDiscKey: position {:#04x}", position);
     DICMDBUF0 = 0xAD020000 | (position << 8);
     DICMDBUF1 = 0;
@@ -280,7 +298,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return DIResult::Success;
   case DIIoctl::DVDLowReset:
   {
-    const bool spinup = Memory::Read_U32(request.buffer_in + 4);
+    const bool spinup = memory.Read_U32(request.buffer_in + 4);
 
     // The GPIO *disables* spinning up the drive.  Normally handled via syscall 0x4e.
     const u32 old_gpio = HW_GPIO_OUT;
@@ -318,8 +336,8 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return DIResult::Success;
   case DIIoctl::DVDLowUnencryptedRead:
   {
-    const u32 length = Memory::Read_U32(request.buffer_in + 4);
-    const u32 position = Memory::Read_U32(request.buffer_in + 8);
+    const u32 length = memory.Read_U32(request.buffer_in + 4);
+    const u32 position = memory.Read_U32(request.buffer_in + 8);
     const u32 end = position + (length >> 2);  // a 32-bit offset
     INFO_LOG_FMT(IOS_DI, "DVDLowUnencryptedRead: offset {:#010x} (byte {:#011x}), length {:#x}",
                  position, static_cast<u64>(position) << 2, length);
@@ -395,8 +413,8 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowReportKey:
   {
-    const u8 param1 = Memory::Read_U8(request.buffer_in + 7);
-    const u32 param2 = Memory::Read_U32(request.buffer_in + 8);
+    const u8 param1 = memory.Read_U8(request.buffer_in + 7);
+    const u32 param2 = memory.Read_U32(request.buffer_in + 8);
     INFO_LOG_FMT(IOS_DI, "DVDLowReportKey: param1 {:#04x}, param2 {:#08x}", param1, param2);
     DICMDBUF0 = 0xA4000000 | (param1 << 16);
     DICMDBUF1 = param2 & 0xFFFFFF;
@@ -405,7 +423,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowSeek:
   {
-    const u32 position = Memory::Read_U32(request.buffer_in + 4);  // 32-bit offset
+    const u32 position = memory.Read_U32(request.buffer_in + 4);  // 32-bit offset
     INFO_LOG_FMT(IOS_DI, "DVDLowSeek: position {:#010x}, translated to {:#010x}", position,
                  position);  // TODO: do partition translation!
     DICMDBUF0 = 0xAB000000;
@@ -414,10 +432,10 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowReadDvd:
   {
-    const u8 flag1 = Memory::Read_U8(request.buffer_in + 7);
-    const u8 flag2 = Memory::Read_U8(request.buffer_in + 11);
-    const u32 length = Memory::Read_U32(request.buffer_in + 12);
-    const u32 position = Memory::Read_U32(request.buffer_in + 16);
+    const u8 flag1 = memory.Read_U8(request.buffer_in + 7);
+    const u8 flag2 = memory.Read_U8(request.buffer_in + 11);
+    const u32 length = memory.Read_U32(request.buffer_in + 12);
+    const u32 position = memory.Read_U32(request.buffer_in + 16);
     INFO_LOG_FMT(IOS_DI, "DVDLowReadDvd({}, {}): position {:#08x}, length {:#08x}", flag1, flag2,
                  position, length);
     DICMDBUF0 = 0xD0000000 | ((flag1 & 1) << 7) | ((flag2 & 1) << 6);
@@ -427,9 +445,9 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowReadDvdConfig:
   {
-    const u8 flag1 = Memory::Read_U8(request.buffer_in + 7);
-    const u8 param2 = Memory::Read_U8(request.buffer_in + 11);
-    const u32 position = Memory::Read_U32(request.buffer_in + 12);
+    const u8 flag1 = memory.Read_U8(request.buffer_in + 7);
+    const u8 param2 = memory.Read_U8(request.buffer_in + 11);
+    const u32 position = memory.Read_U32(request.buffer_in + 12);
     INFO_LOG_FMT(IOS_DI, "DVDLowReadDvdConfig({}, {}): position {:#08x}", flag1, param2, position);
     DICMDBUF0 = 0xD1000000 | ((flag1 & 1) << 16) | param2;
     DICMDBUF1 = position & 0xFFFFFF;
@@ -442,8 +460,8 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return StartImmediateTransfer(request);
   case DIIoctl::DVDLowOffset:
   {
-    const u8 flag = Memory::Read_U8(request.buffer_in + 7);
-    const u32 offset = Memory::Read_U32(request.buffer_in + 8);
+    const u8 flag = memory.Read_U8(request.buffer_in + 7);
+    const u32 offset = memory.Read_U32(request.buffer_in + 8);
     INFO_LOG_FMT(IOS_DI, "DVDLowOffset({}): offset {:#010x}", flag, offset);
     DICMDBUF0 = 0xD9000000 | ((flag & 1) << 16);
     DICMDBUF1 = offset;
@@ -463,15 +481,15 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return StartImmediateTransfer(request);
   case DIIoctl::DVDLowSetMaximumRotation:
   {
-    const u8 speed = Memory::Read_U8(request.buffer_in + 7);
+    const u8 speed = memory.Read_U8(request.buffer_in + 7);
     INFO_LOG_FMT(IOS_DI, "DVDLowSetMaximumRotation: speed {}", speed);
     DICMDBUF0 = 0xDD000000 | ((speed & 3) << 16);
     return StartImmediateTransfer(request, false);
   }
   case DIIoctl::DVDLowSerMeasControl:
   {
-    const u8 flag1 = Memory::Read_U8(request.buffer_in + 7);
-    const u8 flag2 = Memory::Read_U8(request.buffer_in + 11);
+    const u8 flag1 = memory.Read_U8(request.buffer_in + 7);
+    const u8 flag2 = memory.Read_U8(request.buffer_in + 11);
     INFO_LOG_FMT(IOS_DI, "DVDLowSerMeasControl({}, {})", flag1, flag2);
     DICMDBUF0 = 0xDF000000 | ((flag1 & 1) << 17) | ((flag2 & 1) << 16);
     return StartDMATransfer(0x20, request);
@@ -482,9 +500,9 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
     return StartImmediateTransfer(request);
   case DIIoctl::DVDLowAudioStream:
   {
-    const u8 mode = Memory::Read_U8(request.buffer_in + 7);
-    const u32 length = Memory::Read_U32(request.buffer_in + 8);
-    const u32 position = Memory::Read_U32(request.buffer_in + 12);
+    const u8 mode = memory.Read_U8(request.buffer_in + 7);
+    const u32 length = memory.Read_U32(request.buffer_in + 8);
+    const u32 position = memory.Read_U32(request.buffer_in + 12);
     INFO_LOG_FMT(IOS_DI, "DVDLowAudioStream({}): offset {:#010x} (byte {:#011x}), length {:#x}",
                  mode, position, static_cast<u64>(position) << 2, length);
     DICMDBUF0 = 0xE1000000 | ((mode & 3) << 16);
@@ -494,7 +512,7 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowRequestAudioStatus:
   {
-    const u8 mode = Memory::Read_U8(request.buffer_in + 7);
+    const u8 mode = memory.Read_U8(request.buffer_in + 7);
     INFO_LOG_FMT(IOS_DI, "DVDLowRequestAudioStatus({})", mode);
     DICMDBUF0 = 0xE2000000 | ((mode & 3) << 16);
     DICMDBUF1 = 0;
@@ -504,8 +522,8 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowStopMotor:
   {
-    const u8 eject = Memory::Read_U8(request.buffer_in + 7);
-    const u8 kill = Memory::Read_U8(request.buffer_in + 11);
+    const u8 eject = memory.Read_U8(request.buffer_in + 7);
+    const u8 kill = memory.Read_U8(request.buffer_in + 11);
     INFO_LOG_FMT(IOS_DI, "DVDLowStopMotor({}, {})", eject, kill);
     DICMDBUF0 = 0xE3000000 | ((eject & 1) << 17) | ((kill & 1) << 20);
     DICMDBUF1 = 0;
@@ -513,8 +531,8 @@ std::optional<DIDevice::DIResult> DIDevice::StartIOCtl(const IOCtlRequest& reque
   }
   case DIIoctl::DVDLowAudioBufferConfig:
   {
-    const u8 enable = Memory::Read_U8(request.buffer_in + 7);
-    const u8 buffer_size = Memory::Read_U8(request.buffer_in + 11);
+    const u8 enable = memory.Read_U8(request.buffer_in + 7);
+    const u8 buffer_size = memory.Read_U8(request.buffer_in + 11);
     INFO_LOG_FMT(IOS_DI, "DVDLowAudioBufferConfig: {}, buffer size {}",
                  enable ? "enabled" : "disabled", buffer_size);
     DICMDBUF0 = 0xE4000000 | ((enable & 1) << 16) | (buffer_size & 0xf);
@@ -643,9 +661,12 @@ void DIDevice::FinishDICommand(DIResult result)
     return;
   }
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   IOCtlRequest request{m_executing_command->m_request_address};
   if (m_executing_command->m_copy_diimmbuf)
-    Memory::Write_U32(DIIMMBUF, request.buffer_out);
+    memory.Write_U32(DIIMMBUF, request.buffer_out);
 
   m_ios.EnqueueIPCReply(request, static_cast<s32>(result));
 
@@ -672,7 +693,11 @@ std::optional<IPCReply> DIDevice::IOCtlV(const IOCtlVRequest& request)
                   request.in_vectors[0].size);
     return IPCReply{static_cast<s32>(DIResult::BadArgument)};
   }
-  const u8 command = Memory::Read_U8(request.in_vectors[0].address);
+
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u8 command = memory.Read_U8(request.in_vectors[0].address);
   if (request.request != command)
   {
     WARN_LOG_FMT(
@@ -708,7 +733,7 @@ std::optional<IPCReply> DIDevice::IOCtlV(const IOCtlVRequest& request)
     }
 
     const u64 partition_offset =
-        static_cast<u64>(Memory::Read_U32(request.in_vectors[0].address + 4)) << 2;
+        static_cast<u64>(memory.Read_U32(request.in_vectors[0].address + 4)) << 2;
     ChangePartition(DiscIO::Partition(partition_offset));
 
     INFO_LOG_FMT(IOS_DI, "DVDLowOpenPartition: partition_offset {:#011x}", partition_offset);
@@ -716,10 +741,10 @@ std::optional<IPCReply> DIDevice::IOCtlV(const IOCtlVRequest& request)
     // Read TMD to the buffer
     const ES::TMDReader tmd = DVDThread::GetTMD(m_current_partition);
     const std::vector<u8>& raw_tmd = tmd.GetBytes();
-    Memory::CopyToEmu(request.io_vectors[0].address, raw_tmd.data(), raw_tmd.size());
+    memory.CopyToEmu(request.io_vectors[0].address, raw_tmd.data(), raw_tmd.size());
 
     ReturnCode es_result = m_ios.GetES()->DIVerify(tmd, DVDThread::GetTicket(m_current_partition));
-    Memory::Write_U32(es_result, request.io_vectors[1].address);
+    memory.Write_U32(es_result, request.io_vectors[1].address);
 
     return_value = DIResult::Success;
     break;

--- a/Source/Core/Core/IOS/Device.cpp
+++ b/Source/Core/Core/IOS/Device.cpp
@@ -12,19 +12,24 @@
 #include "Core/HW/Memmap.h"
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/IOS.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
 Request::Request(const u32 address_) : address(address_)
 {
-  command = static_cast<IPCCommandType>(Memory::Read_U32(address));
-  fd = Memory::Read_U32(address + 8);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  command = static_cast<IPCCommandType>(memory.Read_U32(address));
+  fd = memory.Read_U32(address + 8);
 }
 
 OpenRequest::OpenRequest(const u32 address_) : Request(address_)
 {
-  path = Memory::GetString(Memory::Read_U32(address + 0xc));
-  flags = static_cast<OpenMode>(Memory::Read_U32(address + 0x10));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  path = memory.GetString(memory.Read_U32(address + 0xc));
+  flags = static_cast<OpenMode>(memory.Read_U32(address + 0x10));
   const Kernel* ios = GetIOS();
   if (ios)
   {
@@ -35,38 +40,46 @@ OpenRequest::OpenRequest(const u32 address_) : Request(address_)
 
 ReadWriteRequest::ReadWriteRequest(const u32 address_) : Request(address_)
 {
-  buffer = Memory::Read_U32(address + 0xc);
-  size = Memory::Read_U32(address + 0x10);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  buffer = memory.Read_U32(address + 0xc);
+  size = memory.Read_U32(address + 0x10);
 }
 
 SeekRequest::SeekRequest(const u32 address_) : Request(address_)
 {
-  offset = Memory::Read_U32(address + 0xc);
-  mode = static_cast<SeekMode>(Memory::Read_U32(address + 0x10));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  offset = memory.Read_U32(address + 0xc);
+  mode = static_cast<SeekMode>(memory.Read_U32(address + 0x10));
 }
 
 IOCtlRequest::IOCtlRequest(const u32 address_) : Request(address_)
 {
-  request = Memory::Read_U32(address + 0x0c);
-  buffer_in = Memory::Read_U32(address + 0x10);
-  buffer_in_size = Memory::Read_U32(address + 0x14);
-  buffer_out = Memory::Read_U32(address + 0x18);
-  buffer_out_size = Memory::Read_U32(address + 0x1c);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  request = memory.Read_U32(address + 0x0c);
+  buffer_in = memory.Read_U32(address + 0x10);
+  buffer_in_size = memory.Read_U32(address + 0x14);
+  buffer_out = memory.Read_U32(address + 0x18);
+  buffer_out_size = memory.Read_U32(address + 0x1c);
 }
 
 IOCtlVRequest::IOCtlVRequest(const u32 address_) : Request(address_)
 {
-  request = Memory::Read_U32(address + 0x0c);
-  const u32 in_number = Memory::Read_U32(address + 0x10);
-  const u32 out_number = Memory::Read_U32(address + 0x14);
-  const u32 vectors_base = Memory::Read_U32(address + 0x18);  // address to vectors
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  request = memory.Read_U32(address + 0x0c);
+  const u32 in_number = memory.Read_U32(address + 0x10);
+  const u32 out_number = memory.Read_U32(address + 0x14);
+  const u32 vectors_base = memory.Read_U32(address + 0x18);  // address to vectors
 
   u32 offset = 0;
   for (size_t i = 0; i < (in_number + out_number); ++i)
   {
     IOVector vector;
-    vector.address = Memory::Read_U32(vectors_base + offset);
-    vector.size = Memory::Read_U32(vectors_base + offset + 4);
+    vector.address = memory.Read_U32(vectors_base + offset);
+    vector.size = memory.Read_U32(vectors_base + offset + 4);
     offset += 8;
     if (i < in_number)
       in_vectors.emplace_back(vector);
@@ -104,11 +117,14 @@ void IOCtlRequest::Log(std::string_view device_name, Common::Log::LogType type,
 void IOCtlRequest::Dump(const std::string& description, Common::Log::LogType type,
                         Common::Log::LogLevel level) const
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   Log("===== " + description, type, level);
   GENERIC_LOG_FMT(type, level, "In buffer\n{}",
-                  HexDump(Memory::GetPointer(buffer_in), buffer_in_size));
+                  HexDump(memory.GetPointer(buffer_in), buffer_in_size));
   GENERIC_LOG_FMT(type, level, "Out buffer\n{}",
-                  HexDump(Memory::GetPointer(buffer_out), buffer_out_size));
+                  HexDump(memory.GetPointer(buffer_out), buffer_out_size));
 }
 
 void IOCtlRequest::DumpUnknown(const std::string& description, Common::Log::LogType type,
@@ -120,6 +136,9 @@ void IOCtlRequest::DumpUnknown(const std::string& description, Common::Log::LogT
 void IOCtlVRequest::Dump(std::string_view description, Common::Log::LogType type,
                          Common::Log::LogLevel level) const
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   GENERIC_LOG_FMT(type, level, "===== {} (fd {}) - IOCtlV {:#x} ({} in, {} io)", description, fd,
                   request, in_vectors.size(), io_vectors.size());
 
@@ -127,7 +146,7 @@ void IOCtlVRequest::Dump(std::string_view description, Common::Log::LogType type
   for (const auto& vector : in_vectors)
   {
     GENERIC_LOG_FMT(type, level, "in[{}] (size={:#x}):\n{}", i++, vector.size,
-                    HexDump(Memory::GetPointer(vector.address), vector.size));
+                    HexDump(memory.GetPointer(vector.address), vector.size));
   }
 
   i = 0;
@@ -147,12 +166,6 @@ Device::Device(Kernel& ios, const std::string& device_name, const DeviceType typ
 }
 
 void Device::DoState(PointerWrap& p)
-{
-  DoStateShared(p);
-  p.Do(m_is_active);
-}
-
-void Device::DoStateShared(PointerWrap& p)
 {
   p.Do(m_name);
   p.Do(m_device_type);

--- a/Source/Core/Core/IOS/Device.h
+++ b/Source/Core/Core/IOS/Device.h
@@ -181,7 +181,6 @@ public:
 
   virtual ~Device() = default;
   virtual void DoState(PointerWrap& p);
-  void DoStateShared(PointerWrap& p);
 
   const std::string& GetDeviceName() const { return m_name; }
   // Replies to Open and Close requests are sent by the IPC request handler (HandleCommand),

--- a/Source/Core/Core/IOS/DolphinDevice.cpp
+++ b/Source/Core/Core/IOS/DolphinDevice.cpp
@@ -19,6 +19,7 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/Host.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -26,7 +27,7 @@ namespace
 {
 enum
 {
-  IOCTL_DOLPHIN_GET_SYSTEM_TIME = 0x01,
+  IOCTL_DOLPHIN_GET_ELAPSED_TIME = 0x01,
   IOCTL_DOLPHIN_GET_VERSION = 0x02,
   IOCTL_DOLPHIN_GET_SPEED_LIMIT = 0x03,
   IOCTL_DOLPHIN_SET_SPEED_LIMIT = 0x04,
@@ -34,27 +35,10 @@ enum
   IOCTL_DOLPHIN_GET_REAL_PRODUCTCODE = 0x06,
   IOCTL_DOLPHIN_DISCORD_SET_CLIENT = 0x07,
   IOCTL_DOLPHIN_DISCORD_SET_PRESENCE = 0x08,
-  IOCTL_DOLPHIN_DISCORD_RESET = 0x09
+  IOCTL_DOLPHIN_DISCORD_RESET = 0x09,
+  IOCTL_DOLPHIN_GET_SYSTEM_TIME = 0x0A,
 
 };
-
-IPCReply GetSystemTime(const IOCtlVRequest& request)
-{
-  if (!request.HasNumberOfValidVectors(0, 1))
-  {
-    return IPCReply(IPC_EINVAL);
-  }
-
-  if (request.io_vectors[0].size != 4)
-  {
-    return IPCReply(IPC_EINVAL);
-  }
-
-  const u32 milliseconds = Common::Timer::NowMs();
-
-  Memory::Write_U32(milliseconds, request.io_vectors[0].address);
-  return IPCReply(IPC_SUCCESS);
-}
 
 IPCReply GetVersion(const IOCtlVRequest& request)
 {
@@ -65,8 +49,10 @@ IPCReply GetVersion(const IOCtlVRequest& request)
 
   const auto length = std::min(size_t(request.io_vectors[0].size), Common::GetScmDescStr().size());
 
-  Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
-  Memory::CopyToEmu(request.io_vectors[0].address, Common::GetScmDescStr().data(), length);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
+  memory.CopyToEmu(request.io_vectors[0].address, Common::GetScmDescStr().data(), length);
 
   return IPCReply(IPC_SUCCESS);
 }
@@ -88,7 +74,9 @@ IPCReply GetCPUSpeed(const IOCtlVRequest& request)
 
   const u32 core_clock = u32(float(SystemTimers::GetTicksPerSecond()) * oc);
 
-  Memory::Write_U32(core_clock, request.io_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(core_clock, request.io_vectors[0].address);
 
   return IPCReply(IPC_SUCCESS);
 }
@@ -107,7 +95,10 @@ IPCReply GetSpeedLimit(const IOCtlVRequest& request)
   }
 
   const u32 speed_percent = Config::Get(Config::MAIN_EMULATION_SPEED) * 100;
-  Memory::Write_U32(speed_percent, request.io_vectors[0].address);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(speed_percent, request.io_vectors[0].address);
 
   return IPCReply(IPC_SUCCESS);
 }
@@ -125,7 +116,9 @@ IPCReply SetSpeedLimit(const IOCtlVRequest& request)
     return IPCReply(IPC_EINVAL);
   }
 
-  const float speed = float(Memory::Read_U32(request.in_vectors[0].address)) / 100.0f;
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const float speed = float(memory.Read_U32(request.in_vectors[0].address)) / 100.0f;
   Config::SetCurrent(Config::MAIN_EMULATION_SPEED, speed);
 
   return IPCReply(IPC_SUCCESS);
@@ -157,8 +150,10 @@ IPCReply GetRealProductCode(const IOCtlVRequest& request)
   if (length == 0)
     return IPCReply(IPC_ENOENT);
 
-  Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
-  Memory::CopyToEmu(request.io_vectors[0].address, code.c_str(), length);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
+  memory.CopyToEmu(request.io_vectors[0].address, code.c_str(), length);
   return IPCReply(IPC_SUCCESS);
 }
 
@@ -169,9 +164,11 @@ IPCReply SetDiscordClient(const IOCtlVRequest& request)
 
   if (!request.HasNumberOfValidVectors(1, 0))
     return IPCReply(IPC_EINVAL);
-
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   std::string new_client_id =
-      Memory::GetString(request.in_vectors[0].address, request.in_vectors[0].size);
+      memory.GetString(request.in_vectors[0].address, request.in_vectors[0].size);
 
   Host_UpdateDiscordClientID(new_client_id);
 
@@ -186,22 +183,24 @@ IPCReply SetDiscordPresence(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(10, 0))
     return IPCReply(IPC_EINVAL);
 
-  std::string details =
-      Memory::GetString(request.in_vectors[0].address, request.in_vectors[0].size);
-  std::string state = Memory::GetString(request.in_vectors[1].address, request.in_vectors[1].size);
-  std::string large_image_key =
-      Memory::GetString(request.in_vectors[2].address, request.in_vectors[2].size);
-  std::string large_image_text =
-      Memory::GetString(request.in_vectors[3].address, request.in_vectors[3].size);
-  std::string small_image_key =
-      Memory::GetString(request.in_vectors[4].address, request.in_vectors[4].size);
-  std::string small_image_text =
-      Memory::GetString(request.in_vectors[5].address, request.in_vectors[5].size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
-  int64_t start_timestamp = Memory::Read_U64(request.in_vectors[6].address);
-  int64_t end_timestamp = Memory::Read_U64(request.in_vectors[7].address);
-  int party_size = Memory::Read_U32(request.in_vectors[8].address);
-  int party_max = Memory::Read_U32(request.in_vectors[9].address);
+  std::string details = memory.GetString(request.in_vectors[0].address, request.in_vectors[0].size);
+  std::string state = memory.GetString(request.in_vectors[1].address, request.in_vectors[1].size);
+  std::string large_image_key =
+      memory.GetString(request.in_vectors[2].address, request.in_vectors[2].size);
+  std::string large_image_text =
+      memory.GetString(request.in_vectors[3].address, request.in_vectors[3].size);
+  std::string small_image_key =
+      memory.GetString(request.in_vectors[4].address, request.in_vectors[4].size);
+  std::string small_image_text =
+      memory.GetString(request.in_vectors[5].address, request.in_vectors[5].size);
+
+  int64_t start_timestamp = memory.Read_U64(request.in_vectors[6].address);
+  int64_t end_timestamp = memory.Read_U64(request.in_vectors[7].address);
+  int party_size = memory.Read_U32(request.in_vectors[8].address);
+  int party_max = memory.Read_U32(request.in_vectors[9].address);;
 
   bool ret = Host_UpdateDiscordPresenceRaw(details, state, large_image_key, large_image_text,
                                            small_image_key, small_image_text, start_timestamp,
@@ -225,6 +224,59 @@ IPCReply ResetDiscord(const IOCtlVRequest& request)
 
 }  // namespace
 
+IPCReply DolphinDevice::GetElapsedTime(const IOCtlVRequest& request) const
+{
+  if (!request.HasNumberOfValidVectors(0, 1))
+  {
+    return IPCReply(IPC_EINVAL);
+  }
+
+  if (request.io_vectors[0].size != 4)
+  {
+    return IPCReply(IPC_EINVAL);
+  }
+
+  // This ioctl is used by emulated software to judge if emulation is running too fast or slow.
+  // By using Common::Timer, the same clock Dolphin uses internally for the same task is exposed.
+  // Return elapsed time instead of current timestamp to make buggy emulated code less likely to
+  // have issues.
+  const u32 milliseconds = static_cast<u32>(m_timer.ElapsedMs());
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(milliseconds, request.io_vectors[0].address);
+  
+  return IPCReply(IPC_SUCCESS);
+}
+
+IPCReply DolphinDevice::GetSystemTime(const IOCtlVRequest& request) const
+{
+  if (!request.HasNumberOfValidVectors(0, 1))
+  {
+    return IPCReply(IPC_EINVAL);
+  }
+
+  if (request.io_vectors[0].size != 8)
+  {
+    return IPCReply(IPC_EINVAL);
+  }
+
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
+  // Write Unix timestamp in milliseconds to memory address
+  const u64 milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count();
+  memory.Write_U64(milliseconds, request.io_vectors[0].address);
+  return IPCReply(IPC_SUCCESS);
+}
+
+DolphinDevice::DolphinDevice(Kernel& ios, const std::string& device_name) : Device(ios, device_name)
+{
+  m_timer.Start();
+}
+
 std::optional<IPCReply> DolphinDevice::IOCtlV(const IOCtlVRequest& request)
 {
   if (Core::WantsDeterminism())
@@ -232,8 +284,8 @@ std::optional<IPCReply> DolphinDevice::IOCtlV(const IOCtlVRequest& request)
 
   switch (request.request)
   {
-  case IOCTL_DOLPHIN_GET_SYSTEM_TIME:
-    return GetSystemTime(request);
+  case IOCTL_DOLPHIN_GET_ELAPSED_TIME:
+    return GetElapsedTime(request);
   case IOCTL_DOLPHIN_GET_VERSION:
     return GetVersion(request);
   case IOCTL_DOLPHIN_GET_SPEED_LIMIT:
@@ -250,6 +302,8 @@ std::optional<IPCReply> DolphinDevice::IOCtlV(const IOCtlVRequest& request)
     return SetDiscordPresence(request);
   case IOCTL_DOLPHIN_DISCORD_RESET:
     return ResetDiscord(request);
+  case IOCTL_DOLPHIN_GET_SYSTEM_TIME:
+    return GetSystemTime(request);
 
   default:
     return IPCReply(IPC_EINVAL);

--- a/Source/Core/Core/IOS/DolphinDevice.h
+++ b/Source/Core/Core/IOS/DolphinDevice.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Common/Timer.h"
 #include "Core/IOS/Device.h"
 
 namespace IOS::HLE
@@ -10,8 +11,13 @@ namespace IOS::HLE
 class DolphinDevice final : public Device
 {
 public:
-  // Inherit the constructor from the Device class, since we don't need to do anything special.
-  using Device::Device;
+  DolphinDevice(Kernel& ios, const std::string& device_name);
   std::optional<IPCReply> IOCtlV(const IOCtlVRequest& request) override;
+
+private:
+  IPCReply GetElapsedTime(const IOCtlVRequest& request) const;
+  IPCReply GetSystemTime(const IOCtlVRequest& request) const;
+
+  Common::Timer m_timer;
 };
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -202,9 +202,12 @@ IPCReply ESDevice::GetTitleDirectory(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(1, 1))
     return IPCReply(ES_EINVAL);
 
-  const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
-  char* path = reinterpret_cast<char*>(Memory::GetPointer(request.io_vectors[0].address));
+  const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
+
+  char* path = reinterpret_cast<char*>(memory.GetPointer(request.io_vectors[0].address));
   sprintf(path, "/title/%08x/%08x/data", static_cast<u32>(title_id >> 32),
           static_cast<u32>(title_id));
 
@@ -230,7 +233,10 @@ IPCReply ESDevice::GetTitleId(const IOCtlVRequest& request)
   if (ret != IPC_SUCCESS)
     return IPCReply(ret);
 
-  Memory::Write_U64(title_id, request.io_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  memory.Write_U64(title_id, request.io_vectors[0].address);
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_GETTITLEID: {:08x}/{:08x}", static_cast<u32>(title_id >> 32),
                static_cast<u32>(title_id));
   return IPCReply(IPC_SUCCESS);
@@ -278,7 +284,10 @@ IPCReply ESDevice::SetUID(u32 uid, const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != 8)
     return IPCReply(ES_EINVAL);
 
-  const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
 
   const s32 ret = CheckIsAllowedToSetUID(m_ios, uid, m_title_context.tmd);
   if (ret < 0)
@@ -401,7 +410,7 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
     }
     return false;
   }
-  
+
   auto& system = Core::System::GetInstance();
   auto& core_timing = system.GetCoreTiming();
 
@@ -454,7 +463,7 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
   m_pending_ppc_boot_content_path = GetContentPath(tmd.GetTitleId(), content);
   if (!Core::IsRunningAndStarted())
     return BootstrapPPC();
-  
+
   core_timing.RemoveEvent(s_bootstrap_ppc_for_launch_event);
   core_timing.ScheduleEvent(ticks, s_bootstrap_ppc_for_launch_event);
   return true;
@@ -707,7 +716,9 @@ IPCReply ESDevice::GetConsumption(const IOCtlVRequest& request)
     return IPCReply(ES_EINVAL);
 
   // This is at least what crediar's ES module does
-  Memory::Write_U32(0, request.io_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(0, request.io_vectors[1].address);
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_GETCONSUMPTION");
   return IPCReply(IPC_SUCCESS);
 }
@@ -717,12 +728,15 @@ std::optional<IPCReply> ESDevice::Launch(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(2, 0))
     return IPCReply(ES_EINVAL);
 
-  const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  const u32 view = Memory::Read_U32(request.in_vectors[1].address);
-  const u64 ticketid = Memory::Read_U64(request.in_vectors[1].address + 4);
-  const u32 devicetype = Memory::Read_U32(request.in_vectors[1].address + 12);
-  const u64 titleid = Memory::Read_U64(request.in_vectors[1].address + 16);
-  const u16 access = Memory::Read_U16(request.in_vectors[1].address + 24);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
+  const u32 view = memory.Read_U32(request.in_vectors[1].address);
+  const u64 ticketid = memory.Read_U64(request.in_vectors[1].address + 4);
+  const u32 devicetype = memory.Read_U32(request.in_vectors[1].address + 12);
+  const u64 titleid = memory.Read_U64(request.in_vectors[1].address + 16);
+  const u16 access = memory.Read_U16(request.in_vectors[1].address + 24);
 
   INFO_LOG_FMT(IOS_ES, "IOCTL_ES_LAUNCH {:016x} {:08x} {:016x} {:08x} {:016x} {:04x}", title_id,
                view, ticketid, devicetype, titleid, access);
@@ -936,8 +950,11 @@ IPCReply ESDevice::SetUpStreamKey(const Context& context, const IOCtlVRequest& r
     return IPCReply(ES_EINVAL);
   }
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   std::vector<u8> tmd_bytes(request.in_vectors[1].size);
-  Memory::CopyFromEmu(tmd_bytes.data(), request.in_vectors[1].address, tmd_bytes.size());
+  memory.CopyFromEmu(tmd_bytes.data(), request.in_vectors[1].address, tmd_bytes.size());
   const ES::TMDReader tmd{std::move(tmd_bytes)};
 
   if (!tmd.IsValid())
@@ -945,8 +962,8 @@ IPCReply ESDevice::SetUpStreamKey(const Context& context, const IOCtlVRequest& r
 
   u32 handle;
   const ReturnCode ret =
-      SetUpStreamKey(context.uid, Memory::GetPointer(request.in_vectors[0].address), tmd, &handle);
-  Memory::Write_U32(handle, request.io_vectors[0].address);
+      SetUpStreamKey(context.uid, memory.GetPointer(request.in_vectors[0].address), tmd, &handle);
+  memory.Write_U32(handle, request.io_vectors[0].address);
   return IPCReply(ret);
 }
 
@@ -955,7 +972,9 @@ IPCReply ESDevice::DeleteStreamKey(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sizeof(u32))
     return IPCReply(ES_EINVAL);
 
-  const u32 handle = Memory::Read_U32(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const u32 handle = memory.Read_U32(request.in_vectors[0].address);
   return IPCReply(m_ios.GetIOSC().DeleteObject(handle, PID_ES));
 }
 

--- a/Source/Core/Core/IOS/ES/ES.h
+++ b/Source/Core/Core/IOS/ES/ES.h
@@ -91,7 +91,8 @@ public:
 
   ES::TMDReader FindImportTMD(u64 title_id, Ticks ticks = {}) const;
   ES::TMDReader FindInstalledTMD(u64 title_id, Ticks ticks = {}) const;
-  ES::TicketReader FindSignedTicket(u64 title_id) const;
+  ES::TicketReader FindSignedTicket(u64 title_id,
+                                    std::optional<u8> desired_version = std::nullopt) const;
 
   // Get installed titles (in /title) without checking for TMDs at all.
   std::vector<u64> GetInstalledTitles() const;
@@ -157,8 +158,8 @@ public:
                         const std::vector<u8>& certs);
 
   // Views
-  ReturnCode GetV0TicketFromView(const u8* ticket_view, u8* ticket) const;
-  ReturnCode GetTicketFromView(const u8* ticket_view, u8* ticket, u32* ticket_size) const;
+  ReturnCode GetTicketFromView(const u8* ticket_view, u8* ticket, u32* ticket_size,
+                               std::optional<u8> desired_version) const;
 
   ReturnCode SetUpStreamKey(u32 uid, const u8* ticket_view, const ES::TMDReader& tmd, u32* handle);
 

--- a/Source/Core/Core/IOS/ES/Formats.cpp
+++ b/Source/Core/Core/IOS/ES/Formats.cpp
@@ -371,22 +371,49 @@ TicketReader::TicketReader(std::vector<u8> bytes) : SignedBlobReader(std::move(b
 
 bool TicketReader::IsValid() const
 {
-  return IsSignatureValid() && !m_bytes.empty() && m_bytes.size() % sizeof(Ticket) == 0;
+  if (!IsSignatureValid() || m_bytes.empty())
+    return false;
+
+  if (IsV1Ticket())
+    return m_bytes.size() == GetTicketSize();
+
+  return m_bytes.size() % sizeof(Ticket) == 0;
+}
+
+bool TicketReader::IsV1Ticket() const
+{
+  // Version can only be 0 or 1.
+  return GetVersion() == 1;
 }
 
 size_t TicketReader::GetNumberOfTickets() const
 {
+  if (IsV1Ticket())
+    return 1;
+  
   return m_bytes.size() / sizeof(Ticket);
+}
+
+u32 TicketReader::GetTicketSize() const
+{
+  if (IsV1Ticket())
+  {
+    return Common::swap32(m_bytes.data() + sizeof(Ticket) +
+                          offsetof(V1TicketHeader, v1_ticket_size)) +
+           sizeof(Ticket);
+  }
+
+  return sizeof(Ticket);
 }
 
 std::vector<u8> TicketReader::GetRawTicket(u64 ticket_id_to_find) const
 {
   for (size_t i = 0; i < GetNumberOfTickets(); ++i)
   {
-    const auto ticket_begin = m_bytes.begin() + sizeof(ES::Ticket) * i;
+    const auto ticket_begin = m_bytes.begin() + GetTicketSize() * i;
     const u64 ticket_id = Common::swap64(&*ticket_begin + offsetof(ES::Ticket, ticket_id));
     if (ticket_id == ticket_id_to_find)
-      return std::vector<u8>(ticket_begin, ticket_begin + sizeof(ES::Ticket));
+      return {ticket_begin, ticket_begin + GetTicketSize()};
   }
   return {};
 }
@@ -397,16 +424,19 @@ std::vector<u8> TicketReader::GetRawTicketView(u32 ticket_num) const
   const auto ticket_start = m_bytes.cbegin() + sizeof(Ticket) * ticket_num;
   const auto view_start = ticket_start + offsetof(Ticket, ticket_id);
 
-  // Copy the ticket version to the buffer (a single byte extended to 4).
-  std::vector<u8> view(sizeof(TicketView::version));
-  const u32 version = Common::swap32(m_bytes.at(offsetof(Ticket, version)));
-  std::memcpy(view.data(), &version, sizeof(version));
+  std::vector<u8> view(sizeof(u32));
+  view[0] = GetVersion();
 
   // Copy the rest of the ticket view structure from the ticket.
-  view.insert(view.end(), view_start, view_start + (sizeof(TicketView) - sizeof(version)));
+  view.insert(view.end(), view_start, view_start + (sizeof(TicketView) - sizeof(u32)));
   ASSERT(view.size() == sizeof(TicketView));
 
   return view;
+}
+
+u8 TicketReader::GetVersion() const
+{
+  return m_bytes[offsetof(Ticket, version)];
 }
 
 u32 TicketReader::GetDeviceId() const
@@ -461,10 +491,10 @@ void TicketReader::DeleteTicket(u64 ticket_id_to_delete)
   const size_t num_tickets = GetNumberOfTickets();
   for (size_t i = 0; i < num_tickets; ++i)
   {
-    const auto ticket_start = m_bytes.cbegin() + sizeof(Ticket) * i;
+    const auto ticket_start = m_bytes.cbegin() + GetTicketSize() * i;
     const u64 ticket_id = Common::swap64(&*ticket_start + offsetof(Ticket, ticket_id));
     if (ticket_id != ticket_id_to_delete)
-      new_ticket.insert(new_ticket.end(), ticket_start, ticket_start + sizeof(Ticket));
+      new_ticket.insert(new_ticket.end(), ticket_start, ticket_start + GetTicketSize());
   }
 
   m_bytes = std::move(new_ticket);

--- a/Source/Core/Core/IOS/ES/Formats.h
+++ b/Source/Core/Core/IOS/ES/Formats.h
@@ -111,7 +111,7 @@ struct TimeLimit
 
 struct TicketView
 {
-  u32 version;
+  u8 version;
   u64 ticket_id;
   u32 device_id;
   u64 title_id;
@@ -151,6 +151,18 @@ struct Ticket
   TimeLimit time_limits[8];
 };
 static_assert(sizeof(Ticket) == 0x2A4, "Ticket has the wrong size");
+
+struct V1TicketHeader
+{
+  u16 version;
+  u16 header_size;
+  u32 v1_ticket_size;
+  u32 section_header_table_offset;
+  u16 number_of_section_headers;
+  u16 section_header_size;
+  u32 flags;
+};
+static_assert(sizeof(V1TicketHeader) == 0x14, "V1TicketHeader has the wrong size");
 #pragma pack(pop)
 
 constexpr u32 MAX_TMD_SIZE = 0x49e4;
@@ -229,6 +241,7 @@ public:
   explicit TicketReader(std::vector<u8> bytes);
 
   bool IsValid() const;
+  bool IsV1Ticket() const;
 
   std::vector<u8> GetRawTicket(u64 ticket_id) const;
   size_t GetNumberOfTickets() const;
@@ -239,7 +252,9 @@ public:
   // more than just one ticket and generate ticket views for them, so we implement it too.
   std::vector<u8> GetRawTicketView(u32 ticket_num) const;
 
+  u8 GetVersion() const;
   u32 GetDeviceId() const;
+  u32 GetTicketSize() const;
   u64 GetTitleId() const;
   u8 GetCommonKeyIndex() const;
   // Get the decrypted title key.

--- a/Source/Core/Core/IOS/ES/TitleContents.cpp
+++ b/Source/Core/Core/IOS/ES/TitleContents.cpp
@@ -10,6 +10,7 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileSystemProxy.h"
 #include "Core/IOS/Uids.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -56,8 +57,10 @@ IPCReply ESDevice::OpenContent(u32 uid, const IOCtlVRequest& request)
       return ES_EINVAL;
     }
 
-    const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-    const u32 content_index = Memory::Read_U32(request.in_vectors[2].address);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
+    const u32 content_index = memory.Read_U32(request.in_vectors[2].address);
     // TODO: check the ticket view, check permissions.
 
     const auto tmd = FindInstalledTMD(title_id, ticks);
@@ -74,7 +77,9 @@ IPCReply ESDevice::OpenActiveTitleContent(u32 caller_uid, const IOCtlVRequest& r
     if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sizeof(u32))
       return ES_EINVAL;
 
-    const u32 content_index = Memory::Read_U32(request.in_vectors[0].address);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    const u32 content_index = memory.Read_U32(request.in_vectors[0].address);
 
     if (!m_title_context.active)
       return ES_EINVAL;
@@ -109,13 +114,15 @@ IPCReply ESDevice::ReadContent(u32 uid, const IOCtlVRequest& request)
     if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != sizeof(u32))
       return ES_EINVAL;
 
-    const u32 cfd = Memory::Read_U32(request.in_vectors[0].address);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    const u32 cfd = memory.Read_U32(request.in_vectors[0].address);
     const u32 size = request.io_vectors[0].size;
     const u32 addr = request.io_vectors[0].address;
 
     INFO_LOG_FMT(IOS_ES, "ReadContent(uid={:#x}, cfd={}, size={}, addr={:08x})", uid, cfd, size,
                  addr);
-    return ReadContent(cfd, Memory::GetPointer(addr), size, uid, ticks);
+    return ReadContent(cfd, memory.GetPointer(addr), size, uid, ticks);
   });
 }
 
@@ -142,7 +149,9 @@ IPCReply ESDevice::CloseContent(u32 uid, const IOCtlVRequest& request)
     if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sizeof(u32))
       return ES_EINVAL;
 
-    const u32 cfd = Memory::Read_U32(request.in_vectors[0].address);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    const u32 cfd = memory.Read_U32(request.in_vectors[0].address);
     return CloseContent(cfd, uid, ticks);
   });
 }
@@ -167,9 +176,11 @@ IPCReply ESDevice::SeekContent(u32 uid, const IOCtlVRequest& request)
     if (!request.HasNumberOfValidVectors(3, 0))
       return ES_EINVAL;
 
-    const u32 cfd = Memory::Read_U32(request.in_vectors[0].address);
-    const u32 offset = Memory::Read_U32(request.in_vectors[1].address);
-    const auto mode = static_cast<SeekMode>(Memory::Read_U32(request.in_vectors[2].address));
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    const u32 cfd = memory.Read_U32(request.in_vectors[0].address);
+    const u32 offset = memory.Read_U32(request.in_vectors[1].address);
+    const auto mode = static_cast<SeekMode>(memory.Read_U32(request.in_vectors[2].address));
 
     return SeekContent(cfd, offset, mode, uid, ticks);
   });

--- a/Source/Core/Core/IOS/ES/TitleManagement.cpp
+++ b/Source/Core/Core/IOS/ES/TitleManagement.cpp
@@ -19,14 +19,16 @@
 #include "Core/IOS/ES/Formats.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/Uids.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
 static ReturnCode WriteTicket(FS::FileSystem* fs, const ES::TicketReader& ticket)
 {
   const u64 title_id = ticket.GetTitleId();
+  const std::string path = ticket.IsV1Ticket() ? Common::GetV1TicketFileName(title_id) :
+                                                 Common::GetTicketFileName(title_id);
 
-  const std::string path = Common::GetTicketFileName(title_id);
   constexpr FS::Modes ticket_modes{FS::Mode::ReadWrite, FS::Mode::ReadWrite, FS::Mode::None};
   fs->CreateFullPath(PID_KERNEL, PID_KERNEL, path, 0, ticket_modes);
   const auto file = fs->CreateAndOpenFile(PID_KERNEL, PID_KERNEL, path, ticket_modes);
@@ -95,11 +97,14 @@ IPCReply ESDevice::ImportTicket(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(3, 0))
     return IPCReply(ES_EINVAL);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   std::vector<u8> bytes(request.in_vectors[0].size);
-  Memory::CopyFromEmu(bytes.data(), request.in_vectors[0].address, request.in_vectors[0].size);
+  memory.CopyFromEmu(bytes.data(), request.in_vectors[0].address, request.in_vectors[0].size);
   std::vector<u8> cert_chain(request.in_vectors[1].size);
-  Memory::CopyFromEmu(cert_chain.data(), request.in_vectors[1].address, request.in_vectors[1].size);
+  memory.CopyFromEmu(cert_chain.data(), request.in_vectors[1].address, request.in_vectors[1].size);
   return IPCReply(ImportTicket(bytes, cert_chain));
 }
 
@@ -185,9 +190,12 @@ IPCReply ESDevice::ImportTmd(Context& context, const IOCtlVRequest& request)
 
   if (!ES::IsValidTMDSize(request.in_vectors[0].size))
     return IPCReply(ES_EINVAL);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   std::vector<u8> tmd(request.in_vectors[0].size);
-  Memory::CopyFromEmu(tmd.data(), request.in_vectors[0].address, request.in_vectors[0].size);
+  memory.CopyFromEmu(tmd.data(), request.in_vectors[0].address, request.in_vectors[0].size);
   return IPCReply(ImportTmd(context, tmd, m_title_context.tmd.GetTitleId(),
                             m_title_context.tmd.GetTitleFlags()));
 }
@@ -271,11 +279,14 @@ IPCReply ESDevice::ImportTitleInit(Context& context, const IOCtlVRequest& reques
 
   if (!ES::IsValidTMDSize(request.in_vectors[0].size))
     return IPCReply(ES_EINVAL);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   std::vector<u8> tmd(request.in_vectors[0].size);
-  Memory::CopyFromEmu(tmd.data(), request.in_vectors[0].address, request.in_vectors[0].size);
+  memory.CopyFromEmu(tmd.data(), request.in_vectors[0].address, request.in_vectors[0].size);
   std::vector<u8> certs(request.in_vectors[1].size);
-  Memory::CopyFromEmu(certs.data(), request.in_vectors[1].address, request.in_vectors[1].size);
+  memory.CopyFromEmu(certs.data(), request.in_vectors[1].address, request.in_vectors[1].size);
   return IPCReply(ImportTitleInit(context, tmd, certs));
 }
 
@@ -327,8 +338,11 @@ IPCReply ESDevice::ImportContentBegin(Context& context, const IOCtlVRequest& req
   if (!request.HasNumberOfValidVectors(2, 0))
     return IPCReply(ES_EINVAL);
 
-  u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  u32 content_id = Memory::Read_U32(request.in_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u64 title_id = memory.Read_U64(request.in_vectors[0].address);
+  u32 content_id = memory.Read_U32(request.in_vectors[1].address);
   return IPCReply(ImportContentBegin(context, title_id, content_id));
 }
 
@@ -346,8 +360,11 @@ IPCReply ESDevice::ImportContentData(Context& context, const IOCtlVRequest& requ
   if (!request.HasNumberOfValidVectors(2, 0))
     return IPCReply(ES_EINVAL);
 
-  u32 content_fd = Memory::Read_U32(request.in_vectors[0].address);
-  u8* data_start = Memory::GetPointer(request.in_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 content_fd = memory.Read_U32(request.in_vectors[0].address);
+  u8* data_start = memory.GetPointer(request.in_vectors[1].address);
   return IPCReply(ImportContentData(context, content_fd, data_start, request.in_vectors[1].size));
 }
 
@@ -429,7 +446,10 @@ IPCReply ESDevice::ImportContentEnd(Context& context, const IOCtlVRequest& reque
   if (!request.HasNumberOfValidVectors(1, 0))
     return IPCReply(ES_EINVAL);
 
-  u32 content_fd = Memory::Read_U32(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 content_fd = memory.Read_U32(request.in_vectors[0].address);
   return IPCReply(ImportContentEnd(context, content_fd));
 }
 
@@ -541,7 +561,10 @@ IPCReply ESDevice::DeleteTitle(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != 8)
     return IPCReply(ES_EINVAL);
 
-  const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
   return IPCReply(DeleteTitle(title_id));
 }
 
@@ -561,7 +584,9 @@ ReturnCode ESDevice::DeleteTicket(const u8* ticket_view)
   ticket.DeleteTicket(ticket_id);
 
   const std::vector<u8>& new_ticket = ticket.GetBytes();
-  const std::string ticket_path = Common::GetTicketFileName(title_id);
+  const std::string ticket_path = ticket.IsV1Ticket() ? Common::GetV1TicketFileName(title_id) :
+                                                        Common::GetTicketFileName(title_id);
+  
   if (!new_ticket.empty())
   {
     const auto file = fs->OpenFile(PID_KERNEL, PID_KERNEL, ticket_path, FS::Mode::ReadWrite);
@@ -592,7 +617,9 @@ IPCReply ESDevice::DeleteTicket(const IOCtlVRequest& request)
   {
     return IPCReply(ES_EINVAL);
   }
-  return IPCReply(DeleteTicket(Memory::GetPointer(request.in_vectors[0].address)));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  return IPCReply(DeleteTicket(memory.GetPointer(request.in_vectors[0].address)));
 }
 
 ReturnCode ESDevice::DeleteTitleContent(u64 title_id) const
@@ -618,7 +645,10 @@ IPCReply ESDevice::DeleteTitleContent(const IOCtlVRequest& request)
 {
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sizeof(u64))
     return IPCReply(ES_EINVAL);
-  return IPCReply(DeleteTitleContent(Memory::Read_U64(request.in_vectors[0].address)));
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  return IPCReply(DeleteTitleContent(memory.Read_U64(request.in_vectors[0].address)));
 }
 
 ReturnCode ESDevice::DeleteContent(u64 title_id, u32 content_id) const
@@ -646,8 +676,10 @@ IPCReply ESDevice::DeleteContent(const IOCtlVRequest& request)
   {
     return IPCReply(ES_EINVAL);
   }
-  return IPCReply(DeleteContent(Memory::Read_U64(request.in_vectors[0].address),
-                                Memory::Read_U32(request.in_vectors[1].address)));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  return IPCReply(DeleteContent(memory.Read_U64(request.in_vectors[0].address),
+                                memory.Read_U32(request.in_vectors[1].address)));
 }
 
 ReturnCode ESDevice::ExportTitleInit(Context& context, u64 title_id, u8* tmd_bytes, u32 tmd_size,
@@ -684,8 +716,11 @@ IPCReply ESDevice::ExportTitleInit(Context& context, const IOCtlVRequest& reques
   if (!request.HasNumberOfValidVectors(1, 1) || request.in_vectors[0].size != 8)
     return IPCReply(ES_EINVAL);
 
-  const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  u8* tmd_bytes = Memory::GetPointer(request.io_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
+  u8* tmd_bytes = memory.GetPointer(request.io_vectors[0].address);
   const u32 tmd_size = request.io_vectors[0].size;
 
   return IPCReply(ExportTitleInit(context, title_id, tmd_bytes, tmd_size,
@@ -730,8 +765,11 @@ IPCReply ESDevice::ExportContentBegin(Context& context, const IOCtlVRequest& req
       request.in_vectors[1].size != 4)
     return IPCReply(ES_EINVAL);
 
-  const u64 title_id = Memory::Read_U64(request.in_vectors[0].address);
-  const u32 content_id = Memory::Read_U32(request.in_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u64 title_id = memory.Read_U64(request.in_vectors[0].address);
+  const u32 content_id = memory.Read_U32(request.in_vectors[1].address);
 
   return IPCReply(ExportContentBegin(context, title_id, content_id));
 }
@@ -778,8 +816,11 @@ IPCReply ESDevice::ExportContentData(Context& context, const IOCtlVRequest& requ
     return IPCReply(ES_EINVAL);
   }
 
-  const u32 content_fd = Memory::Read_U32(request.in_vectors[0].address);
-  u8* data = Memory::GetPointer(request.io_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 content_fd = memory.Read_U32(request.in_vectors[0].address);
+  u8* data = memory.GetPointer(request.io_vectors[0].address);
   const u32 bytes_to_read = request.io_vectors[0].size;
 
   return IPCReply(ExportContentData(context, content_fd, data, bytes_to_read));
@@ -797,7 +838,10 @@ IPCReply ESDevice::ExportContentEnd(Context& context, const IOCtlVRequest& reque
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != 4)
     return IPCReply(ES_EINVAL);
 
-  const u32 content_fd = Memory::Read_U32(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 content_fd = memory.Read_U32(request.in_vectors[0].address);
   return IPCReply(ExportContentEnd(context, content_fd));
 }
 
@@ -854,7 +898,11 @@ IPCReply ESDevice::DeleteSharedContent(const IOCtlVRequest& request)
   std::array<u8, 20> sha1;
   if (!request.HasNumberOfValidVectors(1, 0) || request.in_vectors[0].size != sha1.size())
     return IPCReply(ES_EINVAL);
-  Memory::CopyFromEmu(sha1.data(), request.in_vectors[0].address, request.in_vectors[0].size);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  memory.CopyFromEmu(sha1.data(), request.in_vectors[0].address, request.in_vectors[0].size);
   return IPCReply(DeleteSharedContent(sha1));
 }
 }  // namespace IOS::HLE

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -16,6 +16,7 @@
 #include "Core/HW/SystemTimers.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/Uids.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -93,6 +94,7 @@ FSDevice::FSDevice(Kernel& ios, const std::string& device_name) : Device(ios, de
 
 void FSDevice::DoState(PointerWrap& p)
 {
+  Device::DoState(p);
   p.Do(m_dirty_cache);
   p.Do(m_cache_chain_index);
   p.Do(m_cache_fd);
@@ -311,7 +313,9 @@ bool FSDevice::HasCacheForFile(u64 fd, u32 offset) const
 std::optional<IPCReply> FSDevice::Read(const ReadWriteRequest& request)
 {
   return MakeIPCReply([&](Ticks t) {
-    return Read(request.fd, Memory::GetPointer(request.buffer), request.size, request.buffer, t);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    return Read(request.fd, memory.GetPointer(request.buffer), request.size, request.buffer, t);
   });
 }
 
@@ -339,7 +343,9 @@ s32 FSDevice::Read(u64 fd, u8* data, u32 size, std::optional<u32> ipc_buffer_add
 std::optional<IPCReply> FSDevice::Write(const ReadWriteRequest& request)
 {
   return MakeIPCReply([&](Ticks t) {
-    return Write(request.fd, Memory::GetPointer(request.buffer), request.size, request.buffer, t);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    return Write(request.fd, memory.GetPointer(request.buffer), request.size, request.buffer, t);
   });
 }
 
@@ -421,8 +427,11 @@ static Result<T> GetParams(const IOCtlRequest& request)
   if (request.buffer_in_size < sizeof(T))
     return ResultCode::Invalid;
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   T params;
-  Memory::CopyFromEmu(&params, request.buffer_in, sizeof(params));
+  memory.CopyFromEmu(&params, request.buffer_in, sizeof(params));
   return params;
 }
 
@@ -497,6 +506,9 @@ IPCReply FSDevice::GetStats(const Handle& handle, const IOCtlRequest& request)
   if (!stats)
     return IPCReply(ConvertResult(stats.Error()));
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   ISFSNandStats out;
   out.cluster_size = stats->cluster_size;
   out.free_clusters = stats->free_clusters;
@@ -505,7 +517,7 @@ IPCReply FSDevice::GetStats(const Handle& handle, const IOCtlRequest& request)
   out.reserved_clusters = stats->reserved_clusters;
   out.free_inodes = stats->free_inodes;
   out.used_inodes = stats->used_inodes;
-  Memory::CopyToEmu(request.buffer_out, &out, sizeof(out));
+  memory.CopyToEmu(request.buffer_out, &out, sizeof(out));
   return IPCReply(IPC_SUCCESS);
 }
 
@@ -529,28 +541,31 @@ IPCReply FSDevice::ReadDirectory(const Handle& handle, const IOCtlVRequest& requ
     return GetFSReply(ConvertResult(ResultCode::Invalid));
   }
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   u32 file_list_address, file_count_address, max_count;
   if (request.in_vectors.size() == 2)
   {
     if (request.in_vectors[1].size != 4 || request.io_vectors[1].size != 4)
       return GetFSReply(ConvertResult(ResultCode::Invalid));
-    max_count = Memory::Read_U32(request.in_vectors[1].address);
+    max_count = memory.Read_U32(request.in_vectors[1].address);
     file_count_address = request.io_vectors[1].address;
     file_list_address = request.io_vectors[0].address;
     if (request.io_vectors[0].size != 13 * max_count)
       return GetFSReply(ConvertResult(ResultCode::Invalid));
-    Memory::Write_U32(max_count, file_count_address);
+    memory.Write_U32(max_count, file_count_address);
   }
   else
   {
     if (request.io_vectors[0].size != 4)
       return GetFSReply(ConvertResult(ResultCode::Invalid));
-    max_count = Memory::Read_U32(request.io_vectors[0].address);
+    max_count = memory.Read_U32(request.io_vectors[0].address);
     file_count_address = request.io_vectors[0].address;
     file_list_address = 0;
   }
 
-  const std::string directory = Memory::GetString(request.in_vectors[0].address, 64);
+  const std::string directory = memory.GetString(request.in_vectors[0].address, 64);
   const Result<std::vector<std::string>> list =
       m_ios.GetFS()->ReadDirectory(handle.uid, handle.gid, directory);
   LogResult(list, "ReadDirectory({})", directory);
@@ -559,19 +574,19 @@ IPCReply FSDevice::ReadDirectory(const Handle& handle, const IOCtlVRequest& requ
 
   if (!file_list_address)
   {
-    Memory::Write_U32(static_cast<u32>(list->size()), file_count_address);
+    memory.Write_U32(static_cast<u32>(list->size()), file_count_address);
     return GetFSReply(IPC_SUCCESS);
   }
 
   for (size_t i = 0; i < list->size() && i < max_count; ++i)
   {
-    Memory::Memset(file_list_address, 0, 13);
-    Memory::CopyToEmu(file_list_address, (*list)[i].data(), (*list)[i].size());
-    Memory::Write_U8(0, file_list_address + 12);
+    memory.Memset(file_list_address, 0, 13);
+    memory.CopyToEmu(file_list_address, (*list)[i].data(), (*list)[i].size());
+    memory.Write_U8(0, file_list_address + 12);
     file_list_address += static_cast<u32>((*list)[i].size()) + 1;
   }
   // Write the actual number of entries in the buffer.
-  Memory::Write_U32(std::min(max_count, static_cast<u32>(list->size())), file_count_address);
+  memory.Write_U32(std::min(max_count, static_cast<u32>(list->size())), file_count_address);
   return GetFSReply(IPC_SUCCESS);
 }
 
@@ -592,7 +607,10 @@ IPCReply FSDevice::GetAttribute(const Handle& handle, const IOCtlRequest& reques
   if (request.buffer_in_size < 64 || request.buffer_out_size < sizeof(ISFSParams))
     return GetFSReply(ConvertResult(ResultCode::Invalid));
 
-  const std::string path = Memory::GetString(request.buffer_in, 64);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const std::string path = memory.GetString(request.buffer_in, 64);
   const auto ticks = EstimateFileLookupTicks(path, FileLookupMode::Split);
   const Result<Metadata> metadata = m_ios.GetFS()->GetMetadata(handle.uid, handle.gid, path);
   LogResult(metadata, "GetMetadata({})", path);
@@ -607,7 +625,7 @@ IPCReply FSDevice::GetAttribute(const Handle& handle, const IOCtlRequest& reques
   out.gid = metadata->gid;
   out.attribute = metadata->attribute;
   out.modes = metadata->modes;
-  Memory::CopyToEmu(request.buffer_out, &out, sizeof(out));
+  memory.CopyToEmu(request.buffer_out, &out, sizeof(out));
   return GetFSReply(IPC_SUCCESS, ticks);
 }
 
@@ -626,7 +644,10 @@ IPCReply FSDevice::DeleteFile(const Handle& handle, const IOCtlRequest& request)
   if (request.buffer_in_size < 64)
     return GetFSReply(ConvertResult(ResultCode::Invalid));
 
-  const std::string path = Memory::GetString(request.buffer_in, 64);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const std::string path = memory.GetString(request.buffer_in, 64);
   return MakeIPCReply(
       [&](Ticks ticks) { return ConvertResult(DeleteFile(handle.uid, handle.gid, path, ticks)); });
 }
@@ -647,8 +668,11 @@ IPCReply FSDevice::RenameFile(const Handle& handle, const IOCtlRequest& request)
   if (request.buffer_in_size < 64 * 2)
     return GetFSReply(ConvertResult(ResultCode::Invalid));
 
-  const std::string old_path = Memory::GetString(request.buffer_in, 64);
-  const std::string new_path = Memory::GetString(request.buffer_in + 64, 64);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const std::string old_path = memory.GetString(request.buffer_in, 64);
+  const std::string new_path = memory.GetString(request.buffer_in + 64, 64);
   return MakeIPCReply([&](Ticks ticks) {
     return ConvertResult(RenameFile(handle.uid, handle.gid, old_path, new_path, ticks));
   });
@@ -698,10 +722,13 @@ IPCReply FSDevice::GetFileStats(const Handle& handle, const IOCtlRequest& reques
     if (!status)
       return ConvertResult(status.Error());
 
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+
     ISFSFileStats out;
     out.size = status->size;
     out.seek_position = status->offset;
-    Memory::CopyToEmu(request.buffer_out, &out, sizeof(out));
+    memory.CopyToEmu(request.buffer_out, &out, sizeof(out));
     return IPC_SUCCESS;
   });
 }
@@ -726,14 +753,17 @@ IPCReply FSDevice::GetUsage(const Handle& handle, const IOCtlVRequest& request)
     return GetFSReply(ConvertResult(ResultCode::Invalid));
   }
 
-  const std::string directory = Memory::GetString(request.in_vectors[0].address, 64);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const std::string directory = memory.GetString(request.in_vectors[0].address, 64);
   const Result<DirectoryStats> stats = m_ios.GetFS()->GetDirectoryStats(directory);
   LogResult(stats, "GetDirectoryStats({})", directory);
   if (!stats)
     return GetFSReply(ConvertResult(stats.Error()));
 
-  Memory::Write_U32(stats->used_clusters, request.io_vectors[0].address);
-  Memory::Write_U32(stats->used_inodes, request.io_vectors[1].address);
+  memory.Write_U32(stats->used_clusters, request.io_vectors[0].address);
+  memory.Write_U32(stats->used_inodes, request.io_vectors[1].address);
   return GetFSReply(IPC_SUCCESS);
 }
 

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -104,6 +104,9 @@ constexpr u32 PLACEHOLDER = 0xDEADBEEF;
 
 static bool SetupMemory(u64 ios_title_id, MemorySetupType setup_type)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   auto target_imv = std::find_if(
       GetMemoryValues().begin(), GetMemoryValues().end(),
       [&](const MemoryValues& imv) { return imv.ios_number == (ios_title_id & 0xffff); });
@@ -116,7 +119,7 @@ static bool SetupMemory(u64 ios_title_id, MemorySetupType setup_type)
 
   if (setup_type == MemorySetupType::IOSReload)
   {
-    Memory::Write_U32(target_imv->ios_version, ADDR_IOS_VERSION);
+    memory.Write_U32(target_imv->ios_version, ADDR_IOS_VERSION);
 
     // These values are written by the IOS kernel as part of its boot process (for IOS28 and newer).
     //
@@ -127,15 +130,15 @@ static bool SetupMemory(u64 ios_title_id, MemorySetupType setup_type)
     // the new IOS either updates the range (>= IOS28) or inherits it (< IOS28).
     //
     // We can skip this convoluted process and just write the correct range directly.
-    Memory::Write_U32(target_imv->mem2_physical_size, ADDR_MEM2_SIZE);
-    Memory::Write_U32(target_imv->mem2_simulated_size, ADDR_MEM2_SIM_SIZE);
-    Memory::Write_U32(target_imv->mem2_end, ADDR_MEM2_END);
-    Memory::Write_U32(target_imv->mem2_arena_begin, ADDR_MEM2_ARENA_BEGIN);
-    Memory::Write_U32(target_imv->mem2_arena_end, ADDR_MEM2_ARENA_END);
-    Memory::Write_U32(target_imv->ipc_buffer_begin, ADDR_IPC_BUFFER_BEGIN);
-    Memory::Write_U32(target_imv->ipc_buffer_end, ADDR_IPC_BUFFER_END);
-    Memory::Write_U32(target_imv->ios_reserved_begin, ADDR_IOS_RESERVED_BEGIN);
-    Memory::Write_U32(target_imv->ios_reserved_end, ADDR_IOS_RESERVED_END);
+    memory.Write_U32(target_imv->mem2_physical_size, ADDR_MEM2_SIZE);
+    memory.Write_U32(target_imv->mem2_simulated_size, ADDR_MEM2_SIM_SIZE);
+    memory.Write_U32(target_imv->mem2_end, ADDR_MEM2_END);
+    memory.Write_U32(target_imv->mem2_arena_begin, ADDR_MEM2_ARENA_BEGIN);
+    memory.Write_U32(target_imv->mem2_arena_end, ADDR_MEM2_ARENA_END);
+    memory.Write_U32(target_imv->ipc_buffer_begin, ADDR_IPC_BUFFER_BEGIN);
+    memory.Write_U32(target_imv->ipc_buffer_end, ADDR_IPC_BUFFER_END);
+    memory.Write_U32(target_imv->ios_reserved_begin, ADDR_IOS_RESERVED_BEGIN);
+    memory.Write_U32(target_imv->ios_reserved_end, ADDR_IOS_RESERVED_END);
 
     RAMOverrideForIOSMemoryValues(setup_type);
 
@@ -146,40 +149,40 @@ static bool SetupMemory(u64 ios_title_id, MemorySetupType setup_type)
   // and system information (see below).
   constexpr u32 LOW_MEM1_REGION_START = 0;
   constexpr u32 LOW_MEM1_REGION_SIZE = 0x3fff;
-  Memory::Memset(LOW_MEM1_REGION_START, 0, LOW_MEM1_REGION_SIZE);
+  memory.Memset(LOW_MEM1_REGION_START, 0, LOW_MEM1_REGION_SIZE);
 
-  Memory::Write_U32(target_imv->mem1_physical_size, ADDR_MEM1_SIZE);
-  Memory::Write_U32(target_imv->mem1_simulated_size, ADDR_MEM1_SIM_SIZE);
-  Memory::Write_U32(target_imv->mem1_end, ADDR_MEM1_END);
-  Memory::Write_U32(target_imv->mem1_arena_begin, ADDR_MEM1_ARENA_BEGIN);
-  Memory::Write_U32(target_imv->mem1_arena_end, ADDR_MEM1_ARENA_END);
-  Memory::Write_U32(PLACEHOLDER, ADDR_PH1);
-  Memory::Write_U32(target_imv->mem2_physical_size, ADDR_MEM2_SIZE);
-  Memory::Write_U32(target_imv->mem2_simulated_size, ADDR_MEM2_SIM_SIZE);
-  Memory::Write_U32(target_imv->mem2_end, ADDR_MEM2_END);
-  Memory::Write_U32(target_imv->mem2_arena_begin, ADDR_MEM2_ARENA_BEGIN);
-  Memory::Write_U32(target_imv->mem2_arena_end, ADDR_MEM2_ARENA_END);
-  Memory::Write_U32(PLACEHOLDER, ADDR_PH2);
-  Memory::Write_U32(target_imv->ipc_buffer_begin, ADDR_IPC_BUFFER_BEGIN);
-  Memory::Write_U32(target_imv->ipc_buffer_end, ADDR_IPC_BUFFER_END);
-  Memory::Write_U32(target_imv->hollywood_revision, ADDR_HOLLYWOOD_REVISION);
-  Memory::Write_U32(PLACEHOLDER, ADDR_PH3);
-  Memory::Write_U32(target_imv->ios_version, ADDR_IOS_VERSION);
-  Memory::Write_U32(target_imv->ios_date, ADDR_IOS_DATE);
-  Memory::Write_U32(target_imv->ios_reserved_begin, ADDR_IOS_RESERVED_BEGIN);
-  Memory::Write_U32(target_imv->ios_reserved_end, ADDR_IOS_RESERVED_END);
-  Memory::Write_U32(PLACEHOLDER, ADDR_PH4);
-  Memory::Write_U32(PLACEHOLDER, ADDR_PH5);
-  Memory::Write_U32(target_imv->ram_vendor, ADDR_RAM_VENDOR);
-  Memory::Write_U8(0xDE, ADDR_BOOT_FLAG);
-  Memory::Write_U8(0xAD, ADDR_APPLOADER_FLAG);
-  Memory::Write_U16(0xBEEF, ADDR_DEVKIT_BOOT_PROGRAM_VERSION);
-  Memory::Write_U32(target_imv->sysmenu_sync, ADDR_SYSMENU_SYNC);
+  memory.Write_U32(target_imv->mem1_physical_size, ADDR_MEM1_SIZE);
+  memory.Write_U32(target_imv->mem1_simulated_size, ADDR_MEM1_SIM_SIZE);
+  memory.Write_U32(target_imv->mem1_end, ADDR_MEM1_END);
+  memory.Write_U32(target_imv->mem1_arena_begin, ADDR_MEM1_ARENA_BEGIN);
+  memory.Write_U32(target_imv->mem1_arena_end, ADDR_MEM1_ARENA_END);
+  memory.Write_U32(PLACEHOLDER, ADDR_PH1);
+  memory.Write_U32(target_imv->mem2_physical_size, ADDR_MEM2_SIZE);
+  memory.Write_U32(target_imv->mem2_simulated_size, ADDR_MEM2_SIM_SIZE);
+  memory.Write_U32(target_imv->mem2_end, ADDR_MEM2_END);
+  memory.Write_U32(target_imv->mem2_arena_begin, ADDR_MEM2_ARENA_BEGIN);
+  memory.Write_U32(target_imv->mem2_arena_end, ADDR_MEM2_ARENA_END);
+  memory.Write_U32(PLACEHOLDER, ADDR_PH2);
+  memory.Write_U32(target_imv->ipc_buffer_begin, ADDR_IPC_BUFFER_BEGIN);
+  memory.Write_U32(target_imv->ipc_buffer_end, ADDR_IPC_BUFFER_END);
+  memory.Write_U32(target_imv->hollywood_revision, ADDR_HOLLYWOOD_REVISION);
+  memory.Write_U32(PLACEHOLDER, ADDR_PH3);
+  memory.Write_U32(target_imv->ios_version, ADDR_IOS_VERSION);
+  memory.Write_U32(target_imv->ios_date, ADDR_IOS_DATE);
+  memory.Write_U32(target_imv->ios_reserved_begin, ADDR_IOS_RESERVED_BEGIN);
+  memory.Write_U32(target_imv->ios_reserved_end, ADDR_IOS_RESERVED_END);
+  memory.Write_U32(PLACEHOLDER, ADDR_PH4);
+  memory.Write_U32(PLACEHOLDER, ADDR_PH5);
+  memory.Write_U32(target_imv->ram_vendor, ADDR_RAM_VENDOR);
+  memory.Write_U8(0xDE, ADDR_BOOT_FLAG);
+  memory.Write_U8(0xAD, ADDR_APPLOADER_FLAG);
+  memory.Write_U16(0xBEEF, ADDR_DEVKIT_BOOT_PROGRAM_VERSION);
+  memory.Write_U32(target_imv->sysmenu_sync, ADDR_SYSMENU_SYNC);
 
-  Memory::Write_U32(target_imv->mem1_physical_size, ADDR_LEGACY_MEM_SIZE);
-  Memory::Write_U32(target_imv->mem1_arena_begin, ADDR_LEGACY_ARENA_LOW);
-  Memory::Write_U32(target_imv->mem1_arena_end, ADDR_LEGACY_ARENA_HIGH);
-  Memory::Write_U32(target_imv->mem1_simulated_size, ADDR_LEGACY_MEM_SIM_SIZE);
+  memory.Write_U32(target_imv->mem1_physical_size, ADDR_LEGACY_MEM_SIZE);
+  memory.Write_U32(target_imv->mem1_arena_begin, ADDR_LEGACY_ARENA_LOW);
+  memory.Write_U32(target_imv->mem1_arena_end, ADDR_LEGACY_ARENA_HIGH);
+  memory.Write_U32(target_imv->mem1_simulated_size, ADDR_LEGACY_MEM_SIM_SIZE);
 
   RAMOverrideForIOSMemoryValues(setup_type);
 
@@ -193,14 +196,18 @@ static bool SetupMemory(u64 ios_title_id, MemorySetupType setup_type)
 static void ResetAndPausePPC()
 {
   // This should be cleared when the PPC is released so that the write is not observable.
-  Memory::Write_U32(0x48000000, 0x00000000);  // b 0x0
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(0x48000000, 0x00000000);  // b 0x0
   PowerPC::Reset();
   PC = 0;
 }
 
 static void ReleasePPC()
 {
-  Memory::Write_U32(0, 0);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(0, 0);
   // HLE the bootstub that jumps to 0x3400.
   // NAND titles start with address translation off at 0x3400 (via the PPC bootstub)
   // The state of other CPU registers (like the BAT registers) doesn't matter much
@@ -210,7 +217,9 @@ static void ReleasePPC()
 
 static void ReleasePPCAncast()
 {
-  Memory::Write_U32(0, 0);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(0, 0);
   // On a real console the Espresso verifies and decrypts the Ancast image,
   // then jumps to the decrypted ancast body.
   // The Ancast loader already did this, so just jump to the decrypted body.
@@ -222,20 +231,23 @@ void RAMOverrideForIOSMemoryValues(MemorySetupType setup_type)
   // Don't touch anything if the feature isn't enabled.
   if (!Config::Get(Config::MAIN_RAM_OVERRIDE_ENABLE))
     return;
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   // Some unstated constants that can be inferred.
   const u32 ipc_buffer_size =
-      Memory::Read_U32(ADDR_IPC_BUFFER_END) - Memory::Read_U32(ADDR_IPC_BUFFER_BEGIN);
+      memory.Read_U32(ADDR_IPC_BUFFER_END) - memory.Read_U32(ADDR_IPC_BUFFER_BEGIN);
   const u32 ios_reserved_size =
-      Memory::Read_U32(ADDR_IOS_RESERVED_END) - Memory::Read_U32(ADDR_IOS_RESERVED_BEGIN);
+      memory.Read_U32(ADDR_IOS_RESERVED_END) - memory.Read_U32(ADDR_IOS_RESERVED_BEGIN);
 
-  const u32 mem1_physical_size = Memory::GetRamSizeReal();
-  const u32 mem1_simulated_size = Memory::GetRamSizeReal();
+  const u32 mem1_physical_size = memory.GetRamSizeReal();
+  const u32 mem1_simulated_size = memory.GetRamSizeReal();
   const u32 mem1_end = Memory::MEM1_BASE_ADDR + mem1_simulated_size;
   const u32 mem1_arena_begin = 0;
   const u32 mem1_arena_end = mem1_end;
-  const u32 mem2_physical_size = Memory::GetExRamSizeReal();
-  const u32 mem2_simulated_size = Memory::GetExRamSizeReal();
+  const u32 mem2_physical_size = memory.GetExRamSizeReal();
+  const u32 mem2_simulated_size = memory.GetExRamSizeReal();
   const u32 mem2_end = Memory::MEM2_BASE_ADDR + mem2_simulated_size - ios_reserved_size;
   const u32 mem2_arena_begin = Memory::MEM2_BASE_ADDR + 0x800U;
   const u32 mem2_arena_end = mem2_end - ipc_buffer_size;
@@ -247,31 +259,33 @@ void RAMOverrideForIOSMemoryValues(MemorySetupType setup_type)
   if (setup_type == MemorySetupType::Full)
   {
     // Overwriting these after the game's apploader sets them would be bad
-    Memory::Write_U32(mem1_physical_size, ADDR_MEM1_SIZE);
-    Memory::Write_U32(mem1_simulated_size, ADDR_MEM1_SIM_SIZE);
-    Memory::Write_U32(mem1_end, ADDR_MEM1_END);
-    Memory::Write_U32(mem1_arena_begin, ADDR_MEM1_ARENA_BEGIN);
-    Memory::Write_U32(mem1_arena_end, ADDR_MEM1_ARENA_END);
+    memory.Write_U32(mem1_physical_size, ADDR_MEM1_SIZE);
+    memory.Write_U32(mem1_simulated_size, ADDR_MEM1_SIM_SIZE);
+    memory.Write_U32(mem1_end, ADDR_MEM1_END);
+    memory.Write_U32(mem1_arena_begin, ADDR_MEM1_ARENA_BEGIN);
+    memory.Write_U32(mem1_arena_end, ADDR_MEM1_ARENA_END);
 
-    Memory::Write_U32(mem1_physical_size, ADDR_LEGACY_MEM_SIZE);
-    Memory::Write_U32(mem1_arena_begin, ADDR_LEGACY_ARENA_LOW);
-    Memory::Write_U32(mem1_arena_end, ADDR_LEGACY_ARENA_HIGH);
-    Memory::Write_U32(mem1_simulated_size, ADDR_LEGACY_MEM_SIM_SIZE);
+    memory.Write_U32(mem1_physical_size, ADDR_LEGACY_MEM_SIZE);
+    memory.Write_U32(mem1_arena_begin, ADDR_LEGACY_ARENA_LOW);
+    memory.Write_U32(mem1_arena_end, ADDR_LEGACY_ARENA_HIGH);
+    memory.Write_U32(mem1_simulated_size, ADDR_LEGACY_MEM_SIM_SIZE);
   }
-  Memory::Write_U32(mem2_physical_size, ADDR_MEM2_SIZE);
-  Memory::Write_U32(mem2_simulated_size, ADDR_MEM2_SIM_SIZE);
-  Memory::Write_U32(mem2_end, ADDR_MEM2_END);
-  Memory::Write_U32(mem2_arena_begin, ADDR_MEM2_ARENA_BEGIN);
-  Memory::Write_U32(mem2_arena_end, ADDR_MEM2_ARENA_END);
-  Memory::Write_U32(ipc_buffer_begin, ADDR_IPC_BUFFER_BEGIN);
-  Memory::Write_U32(ipc_buffer_end, ADDR_IPC_BUFFER_END);
-  Memory::Write_U32(ios_reserved_begin, ADDR_IOS_RESERVED_BEGIN);
-  Memory::Write_U32(ios_reserved_end, ADDR_IOS_RESERVED_END);
+  memory.Write_U32(mem2_physical_size, ADDR_MEM2_SIZE);
+  memory.Write_U32(mem2_simulated_size, ADDR_MEM2_SIM_SIZE);
+  memory.Write_U32(mem2_end, ADDR_MEM2_END);
+  memory.Write_U32(mem2_arena_begin, ADDR_MEM2_ARENA_BEGIN);
+  memory.Write_U32(mem2_arena_end, ADDR_MEM2_ARENA_END);
+  memory.Write_U32(ipc_buffer_begin, ADDR_IPC_BUFFER_BEGIN);
+  memory.Write_U32(ipc_buffer_end, ADDR_IPC_BUFFER_END);
+  memory.Write_U32(ios_reserved_begin, ADDR_IOS_RESERVED_BEGIN);
+  memory.Write_U32(ios_reserved_end, ADDR_IOS_RESERVED_END);
 }
 
 void WriteReturnValue(s32 value, u32 address)
 {
-  Memory::Write_U32(static_cast<u32>(value), address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(static_cast<u32>(value), address);
 }
 
 Kernel::Kernel(IOSC::ConsoleType console_type) : m_iosc(console_type)
@@ -751,13 +765,14 @@ void Kernel::EnqueueIPCRequest(u32 address)
 void Kernel::EnqueueIPCReply(const Request& request, const s32 return_value, s64 cycles_in_future,
                              CoreTiming::FromThread from)
 {
-  Memory::Write_U32(static_cast<u32>(return_value), request.address + 4);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(static_cast<u32>(return_value), request.address + 4);
   // IOS writes back the command that was responded to in the FD field.
-  Memory::Write_U32(request.command, request.address + 8);
+  memory.Write_U32(request.command, request.address + 8);
   // IOS also overwrites the command type with the reply type.
-  Memory::Write_U32(IPC_REPLY, request.address);
-  Core::System::GetInstance().GetCoreTiming().ScheduleEvent(cycles_in_future, s_event_enqueue,
-                                                            request.address, from);
+  memory.Write_U32(IPC_REPLY, request.address);
+  system.GetCoreTiming().ScheduleEvent(cycles_in_future, s_event_enqueue, request.address, from);
 }
 
 void Kernel::HandleIPCEvent(u64 userdata)

--- a/Source/Core/Core/IOS/Network/IP/Top.cpp
+++ b/Source/Core/Core/IOS/Network/IP/Top.cpp
@@ -31,6 +31,7 @@
 #include "Core/IOS/Network/ICMP.h"
 #include "Core/IOS/Network/MACUtils.h"
 #include "Core/IOS/Network/Socket.h"
+#include "Core/System.h"
 
 #ifdef _WIN32
 #include <iphlpapi.h>
@@ -75,7 +76,7 @@ NetIPTopDevice::NetIPTopDevice(Kernel& ios, const std::string& device_name)
 
 void NetIPTopDevice::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
+  Device::DoState(p);
   WiiSockMan::GetInstance().DoState(p);
 }
 
@@ -381,9 +382,12 @@ IPCReply NetIPTopDevice::HandleInitInterfaceRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleSocketRequest(const IOCtlRequest& request)
 {
-  const u32 af = Memory::Read_U32(request.buffer_in);
-  const u32 type = Memory::Read_U32(request.buffer_in + 4);
-  const u32 prot = Memory::Read_U32(request.buffer_in + 8);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 af = memory.Read_U32(request.buffer_in);
+  const u32 type = memory.Read_U32(request.buffer_in + 4);
+  const u32 prot = memory.Read_U32(request.buffer_in + 8);
 
   WiiSockMan& sm = WiiSockMan::GetInstance();
   const s32 return_value = sm.NewSocket(af, type, prot);
@@ -398,7 +402,10 @@ IPCReply NetIPTopDevice::HandleSocketRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleICMPSocketRequest(const IOCtlRequest& request)
 {
-  const u32 pf = Memory::Read_U32(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 pf = memory.Read_U32(request.buffer_in);
 
   WiiSockMan& sm = WiiSockMan::GetInstance();
   const s32 return_value = sm.NewSocket(pf, SOCK_RAW, IPPROTO_ICMP);
@@ -408,7 +415,10 @@ IPCReply NetIPTopDevice::HandleICMPSocketRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleCloseRequest(const IOCtlRequest& request)
 {
-  const u32 fd = Memory::Read_U32(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 fd = memory.Read_U32(request.buffer_in);
   WiiSockMan& sm = WiiSockMan::GetInstance();
   const s32 return_value = sm.DeleteSocket(fd);
   const char* const close_fn =
@@ -421,7 +431,10 @@ IPCReply NetIPTopDevice::HandleCloseRequest(const IOCtlRequest& request)
 
 std::optional<IPCReply> NetIPTopDevice::HandleDoSockRequest(const IOCtlRequest& request)
 {
-  const u32 fd = Memory::Read_U32(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 fd = memory.Read_U32(request.buffer_in);
   WiiSockMan& sm = WiiSockMan::GetInstance();
   sm.DoSock(fd, request, static_cast<NET_IOCTL>(request.request));
   return std::nullopt;
@@ -436,8 +449,11 @@ IPCReply NetIPTopDevice::HandleShutdownRequest(const IOCtlRequest& request)
     return IPCReply(-SO_EINVAL);
   }
 
-  const u32 fd = Memory::Read_U32(request.buffer_in);
-  const u32 how = Memory::Read_U32(request.buffer_in + 4);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 fd = memory.Read_U32(request.buffer_in);
+  const u32 how = memory.Read_U32(request.buffer_in + 4);
   WiiSockMan& sm = WiiSockMan::GetInstance();
   const s32 return_value = sm.ShutdownSocket(fd, how);
 
@@ -447,8 +463,11 @@ IPCReply NetIPTopDevice::HandleShutdownRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleListenRequest(const IOCtlRequest& request)
 {
-  u32 fd = Memory::Read_U32(request.buffer_in);
-  u32 BACKLOG = Memory::Read_U32(request.buffer_in + 0x04);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 fd = memory.Read_U32(request.buffer_in);
+  u32 BACKLOG = memory.Read_U32(request.buffer_in + 0x04);
   u32 ret = listen(WiiSockMan::GetInstance().GetHostSocket(fd), BACKLOG);
 
   request.Log(GetDeviceName(), Common::Log::LogType::IOS_WC24);
@@ -457,9 +476,12 @@ IPCReply NetIPTopDevice::HandleListenRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleGetSockOptRequest(const IOCtlRequest& request)
 {
-  u32 fd = Memory::Read_U32(request.buffer_out);
-  u32 level = Memory::Read_U32(request.buffer_out + 4);
-  u32 optname = Memory::Read_U32(request.buffer_out + 8);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 fd = memory.Read_U32(request.buffer_out);
+  u32 level = memory.Read_U32(request.buffer_out + 4);
+  u32 optname = memory.Read_U32(request.buffer_out + 8);
 
   request.Log(GetDeviceName(), Common::Log::LogType::IOS_WC24);
 
@@ -474,15 +496,15 @@ IPCReply NetIPTopDevice::HandleGetSockOptRequest(const IOCtlRequest& request)
                        (char*)&optval, (socklen_t*)&optlen);
   const s32 return_value = WiiSockMan::GetNetErrorCode(ret, "SO_GETSOCKOPT", false);
 
-  Memory::Write_U32(optlen, request.buffer_out + 0xC);
-  Memory::CopyToEmu(request.buffer_out + 0x10, optval, optlen);
+  memory.Write_U32(optlen, request.buffer_out + 0xC);
+  memory.CopyToEmu(request.buffer_out + 0x10, optval, optlen);
 
   if (optname == SO_ERROR)
   {
     s32 last_error = WiiSockMan::GetInstance().GetLastNetError();
 
-    Memory::Write_U32(sizeof(s32), request.buffer_out + 0xC);
-    Memory::Write_U32(last_error, request.buffer_out + 0x10);
+    memory.Write_U32(sizeof(s32), request.buffer_out + 0xC);
+    memory.Write_U32(last_error, request.buffer_out + 0x10);
   }
 
   return IPCReply(return_value);
@@ -490,13 +512,16 @@ IPCReply NetIPTopDevice::HandleGetSockOptRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleSetSockOptRequest(const IOCtlRequest& request)
 {
-  const u32 fd = Memory::Read_U32(request.buffer_in);
-  const u32 level = Memory::Read_U32(request.buffer_in + 4);
-  const u32 optname = Memory::Read_U32(request.buffer_in + 8);
-  u32 optlen = Memory::Read_U32(request.buffer_in + 0xc);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 fd = memory.Read_U32(request.buffer_in);
+  const u32 level = memory.Read_U32(request.buffer_in + 4);
+  const u32 optname = memory.Read_U32(request.buffer_in + 8);
+  u32 optlen = memory.Read_U32(request.buffer_in + 0xc);
   u8 optval[20];
   optlen = std::min(optlen, (u32)sizeof(optval));
-  Memory::CopyFromEmu(optval, request.buffer_in + 0x10, optlen);
+  memory.CopyFromEmu(optval, request.buffer_in + 0x10, optlen);
 
   INFO_LOG_FMT(IOS_NET,
                "IOCTL_SO_SETSOCKOPT({:08x}, {:08x}, {:08x}, {:08x}) "
@@ -525,7 +550,10 @@ IPCReply NetIPTopDevice::HandleSetSockOptRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleGetSockNameRequest(const IOCtlRequest& request)
 {
-  u32 fd = Memory::Read_U32(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 fd = memory.Read_U32(request.buffer_in);
 
   request.Log(GetDeviceName(), Common::Log::LogType::IOS_WC24);
 
@@ -537,13 +565,13 @@ IPCReply NetIPTopDevice::HandleGetSockNameRequest(const IOCtlRequest& request)
     WARN_LOG_FMT(IOS_NET, "IOCTL_SO_GETSOCKNAME output buffer is too small. Truncating");
 
   if (request.buffer_out_size > 0)
-    Memory::Write_U8(request.buffer_out_size, request.buffer_out);
+    memory.Write_U8(request.buffer_out_size, request.buffer_out);
   if (request.buffer_out_size > 1)
-    Memory::Write_U8(sa.sa_family & 0xFF, request.buffer_out + 1);
+    memory.Write_U8(sa.sa_family & 0xFF, request.buffer_out + 1);
   if (request.buffer_out_size > 2)
   {
-    Memory::CopyToEmu(request.buffer_out + 2, &sa.sa_data,
-                      std::min<size_t>(sizeof(sa.sa_data), request.buffer_out_size - 2));
+    memory.CopyToEmu(request.buffer_out + 2, &sa.sa_data,
+                     std::min<size_t>(sizeof(sa.sa_data), request.buffer_out_size - 2));
   }
 
   return IPCReply(ret);
@@ -551,7 +579,10 @@ IPCReply NetIPTopDevice::HandleGetSockNameRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleGetPeerNameRequest(const IOCtlRequest& request)
 {
-  u32 fd = Memory::Read_U32(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 fd = memory.Read_U32(request.buffer_in);
 
   sockaddr sa;
   socklen_t sa_len = sizeof(sa);
@@ -561,13 +592,13 @@ IPCReply NetIPTopDevice::HandleGetPeerNameRequest(const IOCtlRequest& request)
     WARN_LOG_FMT(IOS_NET, "IOCTL_SO_GETPEERNAME output buffer is too small. Truncating");
 
   if (request.buffer_out_size > 0)
-    Memory::Write_U8(request.buffer_out_size, request.buffer_out);
+    memory.Write_U8(request.buffer_out_size, request.buffer_out);
   if (request.buffer_out_size > 1)
-    Memory::Write_U8(AF_INET, request.buffer_out + 1);
+    memory.Write_U8(AF_INET, request.buffer_out + 1);
   if (request.buffer_out_size > 2)
   {
-    Memory::CopyToEmu(request.buffer_out + 2, &sa.sa_data,
-                      std::min<size_t>(sizeof(sa.sa_data), request.buffer_out_size - 2));
+    memory.CopyToEmu(request.buffer_out + 2, &sa.sa_data,
+                     std::min<size_t>(sizeof(sa.sa_data), request.buffer_out_size - 2));
   }
 
   INFO_LOG_FMT(IOS_NET, "IOCTL_SO_GETPEERNAME({:x})", fd);
@@ -585,7 +616,10 @@ IPCReply NetIPTopDevice::HandleGetHostIDRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleInetAToNRequest(const IOCtlRequest& request)
 {
-  const std::string hostname = Memory::GetString(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const std::string hostname = memory.GetString(request.buffer_in);
   struct hostent* remoteHost = gethostbyname(hostname.c_str());
 
   if (remoteHost == nullptr || remoteHost->h_addr_list == nullptr ||
@@ -601,7 +635,7 @@ IPCReply NetIPTopDevice::HandleInetAToNRequest(const IOCtlRequest& request)
   }
 
   const auto ip = Common::swap32(reinterpret_cast<u8*>(remoteHost->h_addr_list[0]));
-  Memory::Write_U32(ip, request.buffer_out);
+  memory.Write_U32(ip, request.buffer_out);
 
   INFO_LOG_FMT(IOS_NET,
                "IOCTL_SO_INETATON = 0 "
@@ -614,24 +648,30 @@ IPCReply NetIPTopDevice::HandleInetAToNRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleInetPToNRequest(const IOCtlRequest& request)
 {
-  const std::string address = Memory::GetString(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const std::string address = memory.GetString(request.buffer_in);
   INFO_LOG_FMT(IOS_NET, "IOCTL_SO_INETPTON (Translating: {})", address);
-  return IPCReply(inet_pton(address.c_str(), Memory::GetPointer(request.buffer_out + 4)));
+  return IPCReply(inet_pton(address.c_str(), memory.GetPointer(request.buffer_out + 4)));
 }
 
 IPCReply NetIPTopDevice::HandleInetNToPRequest(const IOCtlRequest& request)
 {
-  // u32 af = Memory::Read_U32(BufferIn);
-  // u32 validAddress = Memory::Read_U32(request.buffer_in + 4);
-  // u32 src = Memory::Read_U32(request.buffer_in + 8);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  // u32 af = memory.Read_U32(BufferIn);
+  // u32 validAddress = memory.Read_U32(request.buffer_in + 4);
+  // u32 src = memory.Read_U32(request.buffer_in + 8);
 
   char ip_s[16];
-  sprintf(ip_s, "%i.%i.%i.%i", Memory::Read_U8(request.buffer_in + 8),
-          Memory::Read_U8(request.buffer_in + 8 + 1), Memory::Read_U8(request.buffer_in + 8 + 2),
-          Memory::Read_U8(request.buffer_in + 8 + 3));
+  sprintf(ip_s, "%i.%i.%i.%i", memory.Read_U8(request.buffer_in + 8),
+          memory.Read_U8(request.buffer_in + 8 + 1), memory.Read_U8(request.buffer_in + 8 + 2),
+          memory.Read_U8(request.buffer_in + 8 + 3));
 
   INFO_LOG_FMT(IOS_NET, "IOCTL_SO_INETNTOP {}", ip_s);
-  Memory::CopyToEmu(request.buffer_out, reinterpret_cast<u8*>(ip_s), std::strlen(ip_s));
+  memory.CopyToEmu(request.buffer_out, reinterpret_cast<u8*>(ip_s), std::strlen(ip_s));
   return IPCReply(0);
 }
 
@@ -642,8 +682,11 @@ std::optional<IPCReply> NetIPTopDevice::HandlePollRequest(const IOCtlRequest& re
   if (!request.buffer_in || !request.buffer_out)
     return IPCReply(-SO_EINVAL);
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   // Negative timeout indicates wait forever
-  const s64 timeout = static_cast<s64>(Memory::Read_U64(request.buffer_in));
+  const s64 timeout = static_cast<s64>(memory.Read_U64(request.buffer_in));
 
   const u32 nfds = request.buffer_out_size / 0xc;
   if (nfds == 0 || nfds > WII_SOCKET_FD_MAX)
@@ -656,9 +699,9 @@ std::optional<IPCReply> NetIPTopDevice::HandlePollRequest(const IOCtlRequest& re
 
   for (u32 i = 0; i < nfds; ++i)
   {
-    const s32 wii_fd = Memory::Read_U32(request.buffer_out + 0xc * i);
-    ufds[i].fd = sm.GetHostSocket(wii_fd);                                  // fd
-    const int events = Memory::Read_U32(request.buffer_out + 0xc * i + 4);  // events
+    const s32 wii_fd = memory.Read_U32(request.buffer_out + 0xc * i);
+    ufds[i].fd = sm.GetHostSocket(wii_fd);                                 // fd
+    const int events = memory.Read_U32(request.buffer_out + 0xc * i + 4);  // events
     ufds[i].revents = 0;
 
     // Translate Wii to native events
@@ -686,7 +729,10 @@ IPCReply NetIPTopDevice::HandleGetHostByNameRequest(const IOCtlRequest& request)
     return IPCReply(-1);
   }
 
-  const std::string hostname = Memory::GetString(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const std::string hostname = memory.GetString(request.buffer_in);
   hostent* remoteHost = gethostbyname(hostname.c_str());
 
   INFO_LOG_FMT(IOS_NET,
@@ -721,9 +767,8 @@ IPCReply NetIPTopDevice::HandleGetHostByNameRequest(const IOCtlRequest& request)
     ERROR_LOG_FMT(IOS_NET, "Hostname too long in IOCTL_SO_GETHOSTBYNAME");
     return IPCReply(-1);
   }
-  Memory::CopyToEmu(request.buffer_out + GETHOSTBYNAME_STRUCT_SIZE, remoteHost->h_name,
-                    name_length);
-  Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_STRUCT_SIZE, request.buffer_out);
+  memory.CopyToEmu(request.buffer_out + GETHOSTBYNAME_STRUCT_SIZE, remoteHost->h_name, name_length);
+  memory.Write_U32(request.buffer_out + GETHOSTBYNAME_STRUCT_SIZE, request.buffer_out);
 
   // IP address list; located at offset 0x110.
   u32 num_ip_addr = 0;
@@ -736,30 +781,30 @@ IPCReply NetIPTopDevice::HandleGetHostByNameRequest(const IOCtlRequest& request)
   for (u32 i = 0; i < num_ip_addr; ++i)
   {
     u32 addr = request.buffer_out + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4;
-    Memory::Write_U32_Swap(*(u32*)(remoteHost->h_addr_list[i]), addr);
+    memory.Write_U32_Swap(*(u32*)(remoteHost->h_addr_list[i]), addr);
   }
 
   // List of pointers to IP addresses; located at offset 0x340.
   // This must be exact: PPC code to convert the struct hardcodes
   // this offset.
   static const u32 GETHOSTBYNAME_IP_PTR_LIST_OFFSET = 0x340;
-  Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET, request.buffer_out + 12);
+  memory.Write_U32(request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET, request.buffer_out + 12);
   for (u32 i = 0; i < num_ip_addr; ++i)
   {
     u32 addr = request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + i * 4;
-    Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4, addr);
+    memory.Write_U32(request.buffer_out + GETHOSTBYNAME_IP_LIST_OFFSET + i * 4, addr);
   }
-  Memory::Write_U32(0, request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4);
+  memory.Write_U32(0, request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4);
 
   // Aliases - empty. (Hardware doesn't return anything.)
-  Memory::Write_U32(request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4,
-                    request.buffer_out + 4);
+  memory.Write_U32(request.buffer_out + GETHOSTBYNAME_IP_PTR_LIST_OFFSET + num_ip_addr * 4,
+                   request.buffer_out + 4);
 
   // Returned struct must be ipv4.
   ASSERT_MSG(IOS_NET, remoteHost->h_addrtype == AF_INET && remoteHost->h_length == sizeof(u32),
              "returned host info is not IPv4");
-  Memory::Write_U16(AF_INET, request.buffer_out + 8);
-  Memory::Write_U16(sizeof(u32), request.buffer_out + 10);
+  memory.Write_U16(AF_INET, request.buffer_out + 8);
+  memory.Write_U16(sizeof(u32), request.buffer_out + 10);
 
   return IPCReply(0);
 }
@@ -772,10 +817,13 @@ IPCReply NetIPTopDevice::HandleICMPCancelRequest(const IOCtlRequest& request)
 
 IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& request)
 {
-  const u32 param = Memory::Read_U32(request.in_vectors[0].address);
-  const u32 param2 = Memory::Read_U32(request.in_vectors[0].address + 4);
-  const u32 param3 = Memory::Read_U32(request.io_vectors[0].address);
-  const u32 param4 = Memory::Read_U32(request.io_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 param = memory.Read_U32(request.in_vectors[0].address);
+  const u32 param2 = memory.Read_U32(request.in_vectors[0].address + 4);
+  const u32 param3 = memory.Read_U32(request.io_vectors[0].address);
+  const u32 param4 = memory.Read_U32(request.io_vectors[1].address);
   u32 param5 = 0;
 
   if (param != 0xfffe)
@@ -786,7 +834,7 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
 
   if (request.io_vectors[0].size >= 8)
   {
-    param5 = Memory::Read_U32(request.io_vectors[0].address + 4);
+    param5 = memory.Read_U32(request.io_vectors[0].address + 4);
   }
 
   INFO_LOG_FMT(IOS_NET,
@@ -893,63 +941,63 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
     INFO_LOG_FMT(IOS_NET, "Primary DNS: {:X}", address);
     INFO_LOG_FMT(IOS_NET, "Secondary DNS: {:X}", default_backup_dns_resolver);
 
-    Memory::Write_U32(address, request.io_vectors[0].address);
-    Memory::Write_U32(default_backup_dns_resolver, request.io_vectors[0].address + 4);
+    memory.Write_U32(address, request.io_vectors[0].address);
+    memory.Write_U32(default_backup_dns_resolver, request.io_vectors[0].address + 4);
     break;
   }
   case 0x1003:  // error
-    Memory::Write_U32(0, request.io_vectors[0].address);
+    memory.Write_U32(0, request.io_vectors[0].address);
     break;
 
   case 0x1004:  // mac address
   {
     const Common::MACAddress address = IOS::Net::GetMACAddress();
-    Memory::CopyToEmu(request.io_vectors[0].address, address.data(), address.size());
+    memory.CopyToEmu(request.io_vectors[0].address, address.data(), address.size());
     break;
   }
 
   case 0x1005:  // link state
-    Memory::Write_U32(1, request.io_vectors[0].address);
+    memory.Write_U32(1, request.io_vectors[0].address);
     break;
 
   case 0x3001:  // hardcoded value
-    Memory::Write_U32(0x10, request.io_vectors[0].address);
+    memory.Write_U32(0x10, request.io_vectors[0].address);
     break;
 
   case 0x4002:  // ip addr numberHandle
-    Memory::Write_U32(1, request.io_vectors[0].address);
+    memory.Write_U32(1, request.io_vectors[0].address);
     break;
 
   case 0x4003:  // ip addr table
   {
     // XXX: this isn't exactly right; the buffer can be larger than 12 bytes, in which case
     // SO can write 12 more bytes.
-    Memory::Write_U32(0xC, request.io_vectors[1].address);
+    memory.Write_U32(0xC, request.io_vectors[1].address);
     const DefaultInterface interface = GetSystemDefaultInterfaceOrFallback();
-    Memory::Write_U32(Common::swap32(interface.inet), request.io_vectors[0].address);
-    Memory::Write_U32(Common::swap32(interface.netmask), request.io_vectors[0].address + 4);
-    Memory::Write_U32(Common::swap32(interface.broadcast), request.io_vectors[0].address + 8);
+    memory.Write_U32(Common::swap32(interface.inet), request.io_vectors[0].address);
+    memory.Write_U32(Common::swap32(interface.netmask), request.io_vectors[0].address + 4);
+    memory.Write_U32(Common::swap32(interface.broadcast), request.io_vectors[0].address + 8);
     break;
   }
 
   case 0x4005:  // hardcoded value
-    Memory::Write_U32(0x20, request.io_vectors[0].address);
+    memory.Write_U32(0x20, request.io_vectors[0].address);
     break;
 
   case 0x6003:  // hardcoded value
-    Memory::Write_U32(0x80, request.io_vectors[0].address);
+    memory.Write_U32(0x80, request.io_vectors[0].address);
     break;
 
   case 0x600a:  // hardcoded value
-    Memory::Write_U32(0x80, request.io_vectors[0].address);
+    memory.Write_U32(0x80, request.io_vectors[0].address);
     break;
 
   case 0x600c:  // hardcoded value
-    Memory::Write_U32(0x80, request.io_vectors[0].address);
+    memory.Write_U32(0x80, request.io_vectors[0].address);
     break;
 
   case 0xb002:  // hardcoded value
-    Memory::Write_U32(2, request.io_vectors[0].address);
+    memory.Write_U32(2, request.io_vectors[0].address);
     break;
 
   default:
@@ -962,7 +1010,10 @@ IPCReply NetIPTopDevice::HandleGetInterfaceOptRequest(const IOCtlVRequest& reque
 
 std::optional<IPCReply> NetIPTopDevice::HandleSendToRequest(const IOCtlVRequest& request)
 {
-  u32 fd = Memory::Read_U32(request.in_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 fd = memory.Read_U32(request.in_vectors[1].address);
   WiiSockMan& sm = WiiSockMan::GetInstance();
   sm.DoSock(fd, request, IOCTLV_SO_SENDTO);
   return std::nullopt;
@@ -970,7 +1021,10 @@ std::optional<IPCReply> NetIPTopDevice::HandleSendToRequest(const IOCtlVRequest&
 
 std::optional<IPCReply> NetIPTopDevice::HandleRecvFromRequest(const IOCtlVRequest& request)
 {
-  u32 fd = Memory::Read_U32(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  u32 fd = memory.Read_U32(request.in_vectors[0].address);
   WiiSockMan& sm = WiiSockMan::GetInstance();
   sm.DoSock(fd, request, IOCTLV_SO_RECVFROM);
   return std::nullopt;
@@ -978,16 +1032,19 @@ std::optional<IPCReply> NetIPTopDevice::HandleRecvFromRequest(const IOCtlVReques
 
 IPCReply NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& request)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   addrinfo hints;
   const bool hints_valid = request.in_vectors.size() > 2 && request.in_vectors[2].size;
 
   if (hints_valid)
   {
-    hints.ai_flags = Memory::Read_U32(request.in_vectors[2].address);
-    hints.ai_family = Memory::Read_U32(request.in_vectors[2].address + 0x4);
-    hints.ai_socktype = Memory::Read_U32(request.in_vectors[2].address + 0x8);
-    hints.ai_protocol = Memory::Read_U32(request.in_vectors[2].address + 0xC);
-    hints.ai_addrlen = Memory::Read_U32(request.in_vectors[2].address + 0x10);
+    hints.ai_flags = memory.Read_U32(request.in_vectors[2].address);
+    hints.ai_family = memory.Read_U32(request.in_vectors[2].address + 0x4);
+    hints.ai_socktype = memory.Read_U32(request.in_vectors[2].address + 0x8);
+    hints.ai_protocol = memory.Read_U32(request.in_vectors[2].address + 0xC);
+    hints.ai_addrlen = memory.Read_U32(request.in_vectors[2].address + 0x10);
     hints.ai_canonname = nullptr;
     hints.ai_addr = nullptr;
     hints.ai_next = nullptr;
@@ -999,7 +1056,7 @@ IPCReply NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& reques
   const char* pNodeName = nullptr;
   if (!request.in_vectors.empty() && request.in_vectors[0].size > 0)
   {
-    nodeNameStr = Memory::GetString(request.in_vectors[0].address, request.in_vectors[0].size);
+    nodeNameStr = memory.GetString(request.in_vectors[0].address, request.in_vectors[0].size);
     pNodeName = nodeNameStr.c_str();
   }
 
@@ -1007,7 +1064,7 @@ IPCReply NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& reques
   const char* pServiceName = nullptr;
   if (request.in_vectors.size() > 1 && request.in_vectors[1].size > 0)
   {
-    serviceNameStr = Memory::GetString(request.in_vectors[1].address, request.in_vectors[1].size);
+    serviceNameStr = memory.GetString(request.in_vectors[1].address, request.in_vectors[1].size);
     pServiceName = serviceNameStr.c_str();
   }
 
@@ -1020,35 +1077,35 @@ IPCReply NetIPTopDevice::HandleGetAddressInfoRequest(const IOCtlVRequest& reques
     constexpr size_t WII_ADDR_INFO_SIZE = 0x20;
     for (addrinfo* result_iter = result; result_iter != nullptr; result_iter = result_iter->ai_next)
     {
-      Memory::Write_U32(result_iter->ai_flags, addr);
-      Memory::Write_U32(result_iter->ai_family, addr + 0x04);
-      Memory::Write_U32(result_iter->ai_socktype, addr + 0x08);
-      Memory::Write_U32(result_iter->ai_protocol, addr + 0x0C);
-      Memory::Write_U32((u32)result_iter->ai_addrlen, addr + 0x10);
+      memory.Write_U32(result_iter->ai_flags, addr);
+      memory.Write_U32(result_iter->ai_family, addr + 0x04);
+      memory.Write_U32(result_iter->ai_socktype, addr + 0x08);
+      memory.Write_U32(result_iter->ai_protocol, addr + 0x0C);
+      memory.Write_U32((u32)result_iter->ai_addrlen, addr + 0x10);
       // what to do? where to put? the buffer of 0x834 doesn't allow space for this
-      Memory::Write_U32(/*result->ai_cannonname*/ 0, addr + 0x14);
+      memory.Write_U32(/*result->ai_cannonname*/ 0, addr + 0x14);
 
       if (result_iter->ai_addr)
       {
-        Memory::Write_U32(sockoffset, addr + 0x18);
-        Memory::Write_U8(result_iter->ai_addrlen & 0xFF, sockoffset);
-        Memory::Write_U8(result_iter->ai_addr->sa_family & 0xFF, sockoffset + 0x01);
-        Memory::CopyToEmu(sockoffset + 0x2, result_iter->ai_addr->sa_data,
-                          sizeof(result_iter->ai_addr->sa_data));
+        memory.Write_U32(sockoffset, addr + 0x18);
+        memory.Write_U8(result_iter->ai_addrlen & 0xFF, sockoffset);
+        memory.Write_U8(result_iter->ai_addr->sa_family & 0xFF, sockoffset + 0x01);
+        memory.CopyToEmu(sockoffset + 0x2, result_iter->ai_addr->sa_data,
+                         sizeof(result_iter->ai_addr->sa_data));
         sockoffset += 0x1C;
       }
       else
       {
-        Memory::Write_U32(0, addr + 0x18);
+        memory.Write_U32(0, addr + 0x18);
       }
 
       if (result_iter->ai_next)
       {
-        Memory::Write_U32(addr + WII_ADDR_INFO_SIZE, addr + 0x1C);
+        memory.Write_U32(addr + WII_ADDR_INFO_SIZE, addr + 0x1C);
       }
       else
       {
-        Memory::Write_U32(0, addr + 0x1C);
+        memory.Write_U32(0, addr + 0x1C);
       }
 
       addr += WII_ADDR_INFO_SIZE;
@@ -1075,19 +1132,22 @@ IPCReply NetIPTopDevice::HandleICMPPingRequest(const IOCtlVRequest& request)
     u32 ip;
   } ip_info;
 
-  const u32 fd = Memory::Read_U32(request.in_vectors[0].address);
-  const u32 num_ip = Memory::Read_U32(request.in_vectors[0].address + 4);
-  const u64 timeout = Memory::Read_U64(request.in_vectors[0].address + 8);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 fd = memory.Read_U32(request.in_vectors[0].address);
+  const u32 num_ip = memory.Read_U32(request.in_vectors[0].address + 4);
+  const u64 timeout = memory.Read_U64(request.in_vectors[0].address + 8);
 
   if (num_ip != 1)
   {
     INFO_LOG_FMT(IOS_NET, "IOCTLV_SO_ICMPPING {} IPs", num_ip);
   }
 
-  ip_info.length = Memory::Read_U8(request.in_vectors[0].address + 16);
-  ip_info.addr_family = Memory::Read_U8(request.in_vectors[0].address + 17);
-  ip_info.icmp_id = Memory::Read_U16(request.in_vectors[0].address + 18);
-  ip_info.ip = Memory::Read_U32(request.in_vectors[0].address + 20);
+  ip_info.length = memory.Read_U8(request.in_vectors[0].address + 16);
+  ip_info.addr_family = memory.Read_U8(request.in_vectors[0].address + 17);
+  ip_info.icmp_id = memory.Read_U16(request.in_vectors[0].address + 18);
+  ip_info.ip = memory.Read_U32(request.in_vectors[0].address + 20);
 
   if (ip_info.length != 8 || ip_info.addr_family != AF_INET)
   {
@@ -1110,7 +1170,7 @@ IPCReply NetIPTopDevice::HandleICMPPingRequest(const IOCtlVRequest& request)
 
   if (request.in_vectors.size() > 1 && request.in_vectors[1].size == sizeof(data))
   {
-    Memory::CopyFromEmu(data, request.in_vectors[1].address, request.in_vectors[1].size);
+    memory.CopyFromEmu(data, request.in_vectors[1].address, request.in_vectors[1].size);
   }
   else
   {

--- a/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDRequest.cpp
@@ -23,6 +23,7 @@
 #include "Core/IOS/Network/KD/VFF/VFFUtil.h"
 #include "Core/IOS/Network/Socket.h"
 #include "Core/IOS/Uids.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -232,12 +233,14 @@ NWC24::ErrorCode NetKDRequestDevice::KDDownload(const u16 entry_index,
 
 IPCReply NetKDRequestDevice::HandleNWC24DownloadNowEx(const IOCtlRequest& request)
 {
-  const u32 flags = Memory::Read_U32(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const u32 flags = memory.Read_U32(request.buffer_in);
   // Nintendo converts the entry ID between a u32 and u16
   // several times, presumably for alignment purposes.
   // We'll skip past buffer_in+4 and keep the entry index as a u16.
-  const u16 entry_index = Memory::Read_U16(request.buffer_in + 6);
-  const u32 subtask_bitmask = Memory::Read_U32(request.buffer_in + 8);
+  const u16 entry_index = memory.Read_U16(request.buffer_in + 6);
+  const u32 subtask_bitmask = memory.Read_U32(request.buffer_in + 8);
 
   INFO_LOG_FMT(IOS_WC24,
                "NET_KD_REQ: IOCTL_NWC24_DOWNLOAD_NOW_EX - NI - flags: {}, index: {}, bitmask: {}",
@@ -314,7 +317,9 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
     IOCTL_NWC24_SET_SCRIPT_MODE = 0x22,
     IOCTL_NWC24_REQUEST_SHUTDOWN = 0x28,
   };
-
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   s32 return_value = 0;
   switch (request.request)
   {
@@ -335,7 +340,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
 
   case IOCTL_NWC24_STARTUP_SOCKET:  // NWC24iStartupSocket
     WriteReturnValue(0, request.buffer_out);
-    Memory::Write_U32(0, request.buffer_out + 4);
+    memory.Write_U32(0, request.buffer_out + 4);
     return_value = 0;
     INFO_LOG_FMT(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_STARTUP_SOCKET - NI");
     break;
@@ -356,7 +361,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
   case IOCTL_NWC24_REQUEST_REGISTER_USER_ID:
     INFO_LOG_FMT(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_REGISTER_USER_ID");
     WriteReturnValue(0, request.buffer_out);
-    Memory::Write_U32(0, request.buffer_out + 4);
+    memory.Write_U32(0, request.buffer_out + 4);
     break;
 
   case IOCTL_NWC24_REQUEST_GENERATED_USER_ID:  // (Input: none, Output: 32 bytes)
@@ -409,8 +414,8 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
     {
       WriteReturnValue(NWC24::WC24_ERR_ID_REGISTERED, request.buffer_out);
     }
-    Memory::Write_U64(config.Id(), request.buffer_out + 4);
-    Memory::Write_U32(u32(config.CreationStage()), request.buffer_out + 0xC);
+    memory.Write_U64(config.Id(), request.buffer_out + 4);
+    memory.Write_U32(u32(config.CreationStage()), request.buffer_out + 0xC);
     break;
 
   case IOCTL_NWC24_GET_SCHEDULER_STAT:
@@ -435,7 +440,7 @@ std::optional<IPCReply> NetKDRequestDevice::IOCtl(const IOCtlRequest& request)
     }
 
     INFO_LOG_FMT(IOS_WC24, "NET_KD_REQ: IOCTL_NWC24_REQUEST_SHUTDOWN");
-    [[maybe_unused]] const u32 event = Memory::Read_U32(request.buffer_in);
+    [[maybe_unused]] const u32 event = memory.Read_U32(request.buffer_in);
     // TODO: Advertise shutdown event
     // TODO: Shutdown USB keyboard LEDs if event == 3
     // TODO: IOCTLV_NCD_SETCONFIG

--- a/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
+++ b/Source/Core/Core/IOS/Network/KD/NetKDTime.cpp
@@ -8,6 +8,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/EXI/EXI_DeviceIPL.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -33,37 +34,40 @@ std::optional<IPCReply> NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
   u32 common_result = 0;
   // TODO Writes stuff to /shared2/nwc24/misc.bin
   u32 update_misc = 0;
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   switch (request.request)
   {
   case IOCTL_NW24_GET_UNIVERSAL_TIME:
   {
     const u64 adjusted_utc = GetAdjustedUTC();
-    Memory::Write_U64(adjusted_utc, request.buffer_out + 4);
+    memory.Write_U64(adjusted_utc, request.buffer_out + 4);
     INFO_LOG_FMT(IOS_WC24, "IOCTL_NW24_GET_UNIVERSAL_TIME = {}, time = {}", result, adjusted_utc);
   }
   break;
 
   case IOCTL_NW24_SET_UNIVERSAL_TIME:
   {
-    const u64 adjusted_utc = Memory::Read_U64(request.buffer_in);
+    const u64 adjusted_utc = memory.Read_U64(request.buffer_in);
     SetAdjustedUTC(adjusted_utc);
-    update_misc = Memory::Read_U32(request.buffer_in + 8);
+    update_misc = memory.Read_U32(request.buffer_in + 8);
     INFO_LOG_FMT(IOS_WC24, "IOCTL_NW24_SET_UNIVERSAL_TIME ({}, {}) = {}", adjusted_utc, update_misc,
                  result);
   }
   break;
 
   case IOCTL_NW24_SET_RTC_COUNTER:
-    rtc = Memory::Read_U32(request.buffer_in);
-    update_misc = Memory::Read_U32(request.buffer_in + 4);
+    rtc = memory.Read_U32(request.buffer_in);
+    update_misc = memory.Read_U32(request.buffer_in + 4);
     INFO_LOG_FMT(IOS_WC24, "IOCTL_NW24_SET_RTC_COUNTER ({}, {}) = {}", rtc, update_misc, result);
     break;
 
   case IOCTL_NW24_GET_TIME_DIFF:
   {
     const u64 time_diff = GetAdjustedUTC() - rtc;
-    Memory::Write_U64(time_diff, request.buffer_out + 4);
+    memory.Write_U64(time_diff, request.buffer_out + 4);
     INFO_LOG_FMT(IOS_WC24, "IOCTL_NW24_GET_TIME_DIFF = {}, time_diff = {}", result, time_diff);
   }
   break;
@@ -79,7 +83,7 @@ std::optional<IPCReply> NetKDTimeDevice::IOCtl(const IOCtlRequest& request)
   }
 
   // write return values
-  Memory::Write_U32(common_result, request.buffer_out);
+  memory.Write_U32(common_result, request.buffer_out);
   return IPCReply(result);
 }
 

--- a/Source/Core/Core/IOS/Network/NCD/Manage.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/Manage.cpp
@@ -11,6 +11,7 @@
 
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/MACUtils.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -32,6 +33,9 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
   u32 common_result = 0;
   u32 common_vector = 0;
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   switch (request.request)
   {
   case IOCTLV_NCD_LOCKWIRELESSDRIVER:
@@ -52,7 +56,7 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
       // We will just write the value of the file descriptor.
       // The value will be positive so this will work fine.
       m_ipc_fd = request.fd;
-      Memory::Write_U32(request.fd, request.io_vectors[0].address + 4);
+      memory.Write_U32(request.fd, request.io_vectors[0].address + 4);
     }
     break;
 
@@ -67,7 +71,7 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
     if (request.io_vectors[0].size < sizeof(u32))
       return IPCReply(IPC_EINVAL);
 
-    const u32 request_handle = Memory::Read_U32(request.in_vectors[0].address);
+    const u32 request_handle = memory.Read_U32(request.in_vectors[0].address);
     if (m_ipc_fd == request_handle)
     {
       m_ipc_fd = 0;
@@ -107,7 +111,7 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
   case IOCTLV_NCD_GETLINKSTATUS:
     INFO_LOG_FMT(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_GETLINKSTATUS");
     // Always connected
-    Memory::Write_U32(Net::ConnectionSettings::LINK_WIRED, request.io_vectors.at(0).address + 4);
+    memory.Write_U32(Net::ConnectionSettings::LINK_WIRED, request.io_vectors.at(0).address + 4);
     break;
 
   case IOCTLV_NCD_GETWIRELESSMACADDRESS:
@@ -115,7 +119,7 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
     INFO_LOG_FMT(IOS_NET, "NET_NCD_MANAGE: IOCTLV_NCD_GETWIRELESSMACADDRESS");
 
     const Common::MACAddress address = IOS::Net::GetMACAddress();
-    Memory::CopyToEmu(request.io_vectors.at(1).address, address.data(), address.size());
+    memory.CopyToEmu(request.io_vectors.at(1).address, address.data(), address.size());
     break;
   }
 
@@ -124,10 +128,10 @@ std::optional<IPCReply> NetNCDManageDevice::IOCtlV(const IOCtlVRequest& request)
     break;
   }
 
-  Memory::Write_U32(common_result, request.io_vectors.at(common_vector).address);
+  memory.Write_U32(common_result, request.io_vectors.at(common_vector).address);
   if (common_vector == 1)
   {
-    Memory::Write_U32(common_result, request.io_vectors.at(common_vector).address + 4);
+    memory.Write_U32(common_result, request.io_vectors.at(common_vector).address + 4);
   }
   return IPCReply(return_value);
 }

--- a/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
+++ b/Source/Core/Core/IOS/Network/NCD/WiiNetConfig.cpp
@@ -12,6 +12,7 @@
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/Uids.h"
+#include "Core/System.h"
 
 namespace IOS::HLE::Net
 {
@@ -53,11 +54,15 @@ void WiiNetConfig::ResetConfig(FS::FileSystem* fs)
 
 void WiiNetConfig::WriteToMem(const u32 address) const
 {
-  Memory::CopyToEmu(address, &m_data, sizeof(m_data));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyToEmu(address, &m_data, sizeof(m_data));
 }
 
 void WiiNetConfig::ReadFromMem(const u32 address)
 {
-  Memory::CopyFromEmu(&m_data, address, sizeof(m_data));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyFromEmu(&m_data, address, sizeof(m_data));
 }
 }  // namespace IOS::HLE::Net

--- a/Source/Core/Core/IOS/Network/SSL.cpp
+++ b/Source/Core/Core/IOS/Network/SSL.cpp
@@ -20,6 +20,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Network/Socket.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -225,12 +226,15 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   if (Core::WantsDeterminism())
     return IPCReply(IPC_EACCES);
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   switch (request.request)
   {
   case IOCTLV_NET_SSL_NEW:
   {
-    int verifyOption = Memory::Read_U32(BufferOut);
-    std::string hostname = Memory::GetString(BufferOut2, BufferOutSize2);
+    int verifyOption = memory.Read_U32(BufferOut);
+    std::string hostname = memory.GetString(BufferOut2, BufferOutSize2);
 
     int freeSSL = GetSSLFreeID();
     if (freeSSL)
@@ -290,7 +294,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   }
   case IOCTLV_NET_SSL_SHUTDOWN:
   {
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WII_SSL* ssl = &_SSL[sslID];
@@ -335,17 +339,17 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
                  BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3,
                  BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WII_SSL* ssl = &_SSL[sslID];
       int ret =
-          mbedtls_x509_crt_parse_der(&ssl->cacert, Memory::GetPointer(BufferOut2), BufferOutSize2);
+          mbedtls_x509_crt_parse_der(&ssl->cacert, memory.GetPointer(BufferOut2), BufferOutSize2);
 
       if (Config::Get(Config::MAIN_NETWORK_SSL_DUMP_ROOT_CA))
       {
         std::string filename = File::GetUserPath(D_DUMPSSL_IDX) + ssl->hostname + "_rootca.der";
-        File::IOFile(filename, "wb").WriteBytes(Memory::GetPointer(BufferOut2), BufferOutSize2);
+        File::IOFile(filename, "wb").WriteBytes(memory.GetPointer(BufferOut2), BufferOutSize2);
       }
 
       if (ret)
@@ -376,7 +380,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
                  BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3,
                  BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WII_SSL* ssl = &_SSL[sslID];
@@ -423,7 +427,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
                  BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3,
                  BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WII_SSL* ssl = &_SSL[sslID];
@@ -442,7 +446,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   }
   case IOCTLV_NET_SSL_SETBUILTINROOTCA:
   {
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WII_SSL* ssl = &_SSL[sslID];
@@ -480,12 +484,12 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   }
   case IOCTLV_NET_SSL_CONNECT:
   {
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WII_SSL* ssl = &_SSL[sslID];
       mbedtls_ssl_setup(&ssl->ctx, &ssl->config);
-      ssl->sockfd = Memory::Read_U32(BufferOut2);
+      ssl->sockfd = memory.Read_U32(BufferOut2);
       WiiSockMan& sm = WiiSockMan::GetInstance();
       ssl->hostfd = sm.GetHostSocket(ssl->sockfd);
       INFO_LOG_FMT(IOS_SSL, "IOCTLV_NET_SSL_CONNECT socket = {}", ssl->sockfd);
@@ -507,7 +511,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   }
   case IOCTLV_NET_SSL_DOHANDSHAKE:
   {
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
@@ -522,7 +526,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   }
   case IOCTLV_NET_SSL_WRITE:
   {
-    const int sslID = Memory::Read_U32(BufferOut) - 1;
+    const int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
@@ -540,13 +544,13 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
                  "BufferOut2: ({:08x}, {}), BufferOut3: ({:08x}, {})",
                  BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3,
                  BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
-    INFO_LOG_FMT(IOS_SSL, "{}", Memory::GetString(BufferOut2));
+    INFO_LOG_FMT(IOS_SSL, "{}", memory.GetString(BufferOut2));
     break;
   }
   case IOCTLV_NET_SSL_READ:
   {
     int ret = 0;
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WiiSockMan& sm = WiiSockMan::GetInstance();
@@ -569,7 +573,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
   }
   case IOCTLV_NET_SSL_SETROOTCADEFAULT:
   {
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WriteReturnValue(SSL_OK, BufferIn);
@@ -597,7 +601,7 @@ std::optional<IPCReply> NetSSLDevice::IOCtlV(const IOCtlVRequest& request)
                  BufferIn, BufferInSize, BufferIn2, BufferInSize2, BufferIn3, BufferInSize3,
                  BufferOut, BufferOutSize, BufferOut2, BufferOutSize2, BufferOut3, BufferOutSize3);
 
-    int sslID = Memory::Read_U32(BufferOut) - 1;
+    int sslID = memory.Read_U32(BufferOut) - 1;
     if (IsSSLIDValid(sslID))
     {
       WriteReturnValue(SSL_OK, BufferIn);

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -21,6 +21,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/IOS.h"
 #include "Core/IOS/VersionInfo.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -56,7 +57,7 @@ void SDIOSlot0Device::RefreshConfig()
 
 void SDIOSlot0Device::DoState(PointerWrap& p)
 {
-  DoStateShared(p);
+  Device::DoState(p);
   if (p.IsReadMode())
   {
     OpenInternal();
@@ -128,7 +129,9 @@ std::optional<IPCReply> SDIOSlot0Device::Close(u32 fd)
 
 std::optional<IPCReply> SDIOSlot0Device::IOCtl(const IOCtlRequest& request)
 {
-  Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Memset(request.buffer_out, 0, request.buffer_out_size);
 
   switch (request.request)
   {
@@ -187,15 +190,18 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
     u32 pad0;
   } req;
 
-  req.command = Memory::Read_U32(buffer_in + 0);
-  req.type = Memory::Read_U32(buffer_in + 4);
-  req.resp = Memory::Read_U32(buffer_in + 8);
-  req.arg = Memory::Read_U32(buffer_in + 12);
-  req.blocks = Memory::Read_U32(buffer_in + 16);
-  req.bsize = Memory::Read_U32(buffer_in + 20);
-  req.addr = Memory::Read_U32(buffer_in + 24);
-  req.isDMA = Memory::Read_U32(buffer_in + 28);
-  req.pad0 = Memory::Read_U32(buffer_in + 32);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  req.command = memory.Read_U32(buffer_in + 0);
+  req.type = memory.Read_U32(buffer_in + 4);
+  req.resp = memory.Read_U32(buffer_in + 8);
+  req.arg = memory.Read_U32(buffer_in + 12);
+  req.blocks = memory.Read_U32(buffer_in + 16);
+  req.bsize = memory.Read_U32(buffer_in + 20);
+  req.addr = memory.Read_U32(buffer_in + 24);
+  req.isDMA = memory.Read_U32(buffer_in + 28);
+  req.pad0 = memory.Read_U32(buffer_in + 32);
 
   // Note: req.addr is the virtual address of _rwBuffer
 
@@ -206,19 +212,19 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
   case GO_IDLE_STATE:
     INFO_LOG_FMT(IOS_SD, "GO_IDLE_STATE");
     // Response is R1 (idle state)
-    Memory::Write_U32(0x00, buffer_out);
+    memory.Write_U32(0x00, buffer_out);
     break;
 
   case SEND_RELATIVE_ADDR:
     // Technically RCA should be generated when asked and at power on...w/e :p
-    Memory::Write_U32(0x9f62, buffer_out);
+    memory.Write_U32(0x9f62, buffer_out);
     break;
 
   case SELECT_CARD:
     // This covers both select and deselect
     // Differentiate by checking if rca is set in req.arg
     // If it is, it's a select and return 0x700
-    Memory::Write_U32((req.arg >> 16) ? 0x700 : 0x900, buffer_out);
+    memory.Write_U32((req.arg >> 16) ? 0x700 : 0x900, buffer_out);
     break;
 
   case SEND_IF_COND:
@@ -227,45 +233,45 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
     // voltage and the check pattern that were set in the command argument.
     // This command is used to differentiate between protocol v1 and v2.
     InitSDHC();
-    Memory::Write_U32(req.arg, buffer_out);
+    memory.Write_U32(req.arg, buffer_out);
     break;
 
   case SEND_CSD:
   {
     const std::array<u32, 4> csd = m_protocol == SDProtocol::V1 ? GetCSDv1() : GetCSDv2();
-    Memory::CopyToEmuSwapped(buffer_out, csd.data(), csd.size() * sizeof(u32));
+    memory.CopyToEmuSwapped(buffer_out, csd.data(), csd.size() * sizeof(u32));
   }
   break;
 
   case ALL_SEND_CID:
   case SEND_CID:
     INFO_LOG_FMT(IOS_SD, "(ALL_)SEND_CID");
-    Memory::Write_U32(0x80114d1c, buffer_out);
-    Memory::Write_U32(0x80080000, buffer_out + 4);
-    Memory::Write_U32(0x8007b520, buffer_out + 8);
-    Memory::Write_U32(0x80080000, buffer_out + 12);
+    memory.Write_U32(0x80114d1c, buffer_out);
+    memory.Write_U32(0x80080000, buffer_out + 4);
+    memory.Write_U32(0x8007b520, buffer_out + 8);
+    memory.Write_U32(0x80080000, buffer_out + 12);
     break;
 
   case SET_BLOCKLEN:
     m_block_length = req.arg;
-    Memory::Write_U32(0x900, buffer_out);
+    memory.Write_U32(0x900, buffer_out);
     break;
 
   case APP_CMD_NEXT:
     // Next cmd is going to be ACMD_*
-    Memory::Write_U32(0x920, buffer_out);
+    memory.Write_U32(0x920, buffer_out);
     break;
 
   case ACMD_SETBUSWIDTH:
     // 0 = 1bit, 2 = 4bit
     m_bus_width = (req.arg & 3);
-    Memory::Write_U32(0x920, buffer_out);
+    memory.Write_U32(0x920, buffer_out);
     break;
 
   case ACMD_SENDOPCOND:
     // Sends host capacity support information (HCS) and asks the accessed card to send
     // its operating condition register (OCR) content
-    Memory::Write_U32(GetOCRegister(), buffer_out);
+    memory.Write_U32(GetOCRegister(), buffer_out);
     break;
 
   case READ_MULTIPLE_BLOCK:
@@ -283,7 +289,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
       if (!m_card.Seek(address, File::SeekOrigin::Begin))
         ERROR_LOG_FMT(IOS_SD, "Seek failed");
 
-      if (m_card.ReadBytes(Memory::GetPointer(req.addr), size))
+      if (m_card.ReadBytes(memory.GetPointer(req.addr), size))
       {
         DEBUG_LOG_FMT(IOS_SD, "Outbuffer size {} got {}", rw_buffer_size, size);
       }
@@ -295,7 +301,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
       }
     }
   }
-    Memory::Write_U32(0x900, buffer_out);
+    memory.Write_U32(0x900, buffer_out);
     break;
 
   case WRITE_MULTIPLE_BLOCK:
@@ -313,7 +319,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
       if (!m_card.Seek(address, File::SeekOrigin::Begin))
         ERROR_LOG_FMT(IOS_SD, "Seek failed");
 
-      if (!m_card.WriteBytes(Memory::GetPointer(req.addr), size))
+      if (!m_card.WriteBytes(memory.GetPointer(req.addr), size))
       {
         ERROR_LOG_FMT(IOS_SD, "Write Failed - error: {}, eof: {}", std::ferror(m_card.GetHandle()),
                       std::feof(m_card.GetHandle()));
@@ -321,7 +327,7 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
       }
     }
   }
-    Memory::Write_U32(0x900, buffer_out);
+    memory.Write_U32(0x900, buffer_out);
     break;
 
   case EVENT_REGISTER:  // async
@@ -354,8 +360,11 @@ s32 SDIOSlot0Device::ExecuteCommand(const Request& request, u32 buffer_in, u32 b
 
 IPCReply SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
 {
-  const u32 reg = Memory::Read_U32(request.buffer_in);
-  const u32 val = Memory::Read_U32(request.buffer_in + 16);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 reg = memory.Read_U32(request.buffer_in);
+  const u32 val = memory.Read_U32(request.buffer_in + 16);
 
   INFO_LOG_FMT(IOS_SD, "IOCTL_WRITEHCR {:#010x} - {:#010x}", reg, val);
 
@@ -386,7 +395,10 @@ IPCReply SDIOSlot0Device::WriteHCRegister(const IOCtlRequest& request)
 
 IPCReply SDIOSlot0Device::ReadHCRegister(const IOCtlRequest& request)
 {
-  const u32 reg = Memory::Read_U32(request.buffer_in);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u32 reg = memory.Read_U32(request.buffer_in);
 
   if (reg >= m_registers.size())
   {
@@ -398,7 +410,7 @@ IPCReply SDIOSlot0Device::ReadHCRegister(const IOCtlRequest& request)
   INFO_LOG_FMT(IOS_SD, "IOCTL_READHCR {:#010x} - {:#010x}", reg, val);
 
   // Just reading the register
-  Memory::Write_U32(val, request.buffer_out);
+  memory.Write_U32(val, request.buffer_out);
   return IPCReply(IPC_SUCCESS);
 }
 
@@ -406,8 +418,11 @@ IPCReply SDIOSlot0Device::ResetCard(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_RESETCARD");
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   // Returns 16bit RCA and 16bit 0s (meaning success)
-  Memory::Write_U32(m_status, request.buffer_out);
+  memory.Write_U32(m_status, request.buffer_out);
 
   return IPCReply(IPC_SUCCESS);
 }
@@ -416,9 +431,12 @@ IPCReply SDIOSlot0Device::SetClk(const IOCtlRequest& request)
 {
   INFO_LOG_FMT(IOS_SD, "IOCTL_SETCLK");
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   // libogc only sets it to 1 and makes sure the return isn't negative...
   // one half of the sdclk divisor: a power of two or zero.
-  const u32 clock = Memory::Read_U32(request.buffer_in);
+  const u32 clock = memory.Read_U32(request.buffer_in);
   if (clock != 1)
     INFO_LOG_FMT(IOS_SD, "Setting to {}, interesting", clock);
 
@@ -427,7 +445,10 @@ IPCReply SDIOSlot0Device::SetClk(const IOCtlRequest& request)
 
 std::optional<IPCReply> SDIOSlot0Device::SendCommand(const IOCtlRequest& request)
 {
-  INFO_LOG_FMT(IOS_SD, "IOCTL_SENDCMD {:x} IPC:{:08x}", Memory::Read_U32(request.buffer_in),
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  INFO_LOG_FMT(IOS_SD, "IOCTL_SENDCMD {:x} IPC:{:08x}", memory.Read_U32(request.buffer_in),
                request.address);
 
   const s32 return_value = ExecuteCommand(request, request.buffer_in, request.buffer_in_size, 0, 0,
@@ -476,23 +497,31 @@ IPCReply SDIOSlot0Device::GetStatus(const IOCtlRequest& request)
                (status & CARD_INSERTED) ? "inserted" : "not present",
                (status & CARD_INITIALIZED) ? " and initialized" : "");
 
-  Memory::Write_U32(status, request.buffer_out);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(status, request.buffer_out);
   return IPCReply(IPC_SUCCESS);
 }
 
 IPCReply SDIOSlot0Device::GetOCRegister(const IOCtlRequest& request)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   const u32 ocr = GetOCRegister();
   INFO_LOG_FMT(IOS_SD, "IOCTL_GETOCR. Replying with ocr {:x}", ocr);
-  Memory::Write_U32(ocr, request.buffer_out);
+  memory.Write_U32(ocr, request.buffer_out);
 
   return IPCReply(IPC_SUCCESS);
 }
 
 IPCReply SDIOSlot0Device::SendCommand(const IOCtlVRequest& request)
 {
-  DEBUG_LOG_FMT(IOS_SD, "IOCTLV_SENDCMD {:#010x}", Memory::Read_U32(request.in_vectors[0].address));
-  Memory::Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  DEBUG_LOG_FMT(IOS_SD, "IOCTLV_SENDCMD {:#010x}", memory.Read_U32(request.in_vectors[0].address));
+  memory.Memset(request.io_vectors[0].address, 0, request.io_vectors[0].size);
 
   const s32 return_value =
       ExecuteCommand(request, request.in_vectors[0].address, request.in_vectors[0].size,

--- a/Source/Core/Core/IOS/STM/STM.cpp
+++ b/Source/Core/Core/IOS/STM/STM.cpp
@@ -10,6 +10,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -17,6 +18,9 @@ static std::unique_ptr<IOCtlRequest> s_event_hook_request;
 
 std::optional<IPCReply> STMImmediateDevice::IOCtl(const IOCtlRequest& request)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   s32 return_value = IPC_SUCCESS;
   switch (request.request)
   {
@@ -32,7 +36,7 @@ std::optional<IPCReply> STMImmediateDevice::IOCtl(const IOCtlRequest& request)
       return_value = IPC_ENOENT;
       break;
     }
-    Memory::Write_U32(0, s_event_hook_request->buffer_out);
+    memory.Write_U32(0, s_event_hook_request->buffer_out);
     m_ios.EnqueueIPCReply(*s_event_hook_request, IPC_SUCCESS);
     s_event_hook_request.reset();
     break;
@@ -45,7 +49,7 @@ std::optional<IPCReply> STMImmediateDevice::IOCtl(const IOCtlRequest& request)
   case IOCTL_STM_VIDIMMING:  // (Input: 20 bytes, Output: 20 bytes)
     INFO_LOG_FMT(IOS_STM, "{} - IOCtl:", GetDeviceName());
     INFO_LOG_FMT(IOS_STM, "    IOCTL_STM_VIDIMMING");
-    // Memory::Write_U32(1, buffer_out);
+    // memory.Write_U32(1, buffer_out);
     // return_value = 1;
     break;
 
@@ -81,13 +85,13 @@ std::optional<IPCReply> STMEventHookDevice::IOCtl(const IOCtlRequest& request)
 
 void STMEventHookDevice::DoState(PointerWrap& p)
 {
+  Device::DoState(p);
   u32 address = s_event_hook_request ? s_event_hook_request->address : 0;
   p.Do(address);
   if (address != 0)
     s_event_hook_request = std::make_unique<IOCtlRequest>(address);
   else
     s_event_hook_request.reset();
-  Device::DoState(p);
 }
 
 bool STMEventHookDevice::HasHookInstalled() const
@@ -101,7 +105,9 @@ void STMEventHookDevice::TriggerEvent(const u32 event) const
   if (!m_is_active || !s_event_hook_request)
     return;
 
-  Memory::Write_U32(event, s_event_hook_request->buffer_out);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U32(event, s_event_hook_request->buffer_out);
   m_ios.EnqueueIPCReply(*s_event_hook_request, IPC_SUCCESS);
   s_event_hook_request.reset();
 }

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTEmu.cpp
@@ -103,7 +103,7 @@ void BluetoothEmuDevice::DoState(PointerWrap& p)
     return;
   }
 
-  p.Do(m_is_active);
+  Device::DoState(p);
   p.Do(m_controller_bd);
   DoStateForMessage(m_ios, p, m_hci_endpoint);
   DoStateForMessage(m_ios, p, m_acl_endpoint);
@@ -164,15 +164,18 @@ std::optional<IPCReply> BluetoothEmuDevice::IOCtlV(const IOCtlVRequest& request)
     {
     case ACL_DATA_OUT:  // ACL data is received from the stack
     {
+      auto& system = Core::System::GetInstance();
+      auto& memory = system.GetMemory();
+      
       // This is the ACL datapath from CPU to Wii Remote
       const auto* acl_header =
-          reinterpret_cast<hci_acldata_hdr_t*>(Memory::GetPointer(ctrl.data_address));
+          reinterpret_cast<hci_acldata_hdr_t*>(memory.GetPointer(ctrl.data_address));
 
       DEBUG_ASSERT(HCI_BC_FLAG(acl_header->con_handle) == HCI_POINT2POINT);
       DEBUG_ASSERT(HCI_PB_FLAG(acl_header->con_handle) == HCI_PACKET_START);
 
       SendToDevice(HCI_CON_HANDLE(acl_header->con_handle),
-                   Memory::GetPointer(ctrl.data_address + sizeof(hci_acldata_hdr_t)),
+                   memory.GetPointer(ctrl.data_address + sizeof(hci_acldata_hdr_t)),
                    acl_header->length);
       break;
     }
@@ -244,8 +247,11 @@ void BluetoothEmuDevice::SendACLPacket(const bdaddr_t& source, const u8* data, u
     DEBUG_LOG_FMT(IOS_WIIMOTE, "ACL endpoint valid, sending packet to {:08x}",
                   m_acl_endpoint->ios_request.address);
 
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    
     hci_acldata_hdr_t* header =
-        reinterpret_cast<hci_acldata_hdr_t*>(Memory::GetPointer(m_acl_endpoint->data_address));
+        reinterpret_cast<hci_acldata_hdr_t*>(memory.GetPointer(m_acl_endpoint->data_address));
     header->con_handle = HCI_MK_CON_HANDLE(connection_handle, HCI_PACKET_START, HCI_POINT2POINT);
     header->length = size;
 
@@ -421,7 +427,10 @@ void BluetoothEmuDevice::ACLPool::WriteToEndpoint(const USB::V0BulkMessage& endp
   DEBUG_LOG_FMT(IOS_WIIMOTE, "ACL packet being written from queue to {:08x}",
                 endpoint.ios_request.address);
 
-  hci_acldata_hdr_t* header = (hci_acldata_hdr_t*)Memory::GetPointer(endpoint.data_address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  hci_acldata_hdr_t* header = (hci_acldata_hdr_t*)memory.GetPointer(endpoint.data_address);
   header->con_handle = HCI_MK_CON_HANDLE(conn_handle, HCI_PACKET_START, HCI_POINT2POINT);
   header->length = size;
 
@@ -957,10 +966,13 @@ bool BluetoothEmuDevice::SendEventConPacketTypeChange(u16 connection_handle, u16
 // This is called from the USB::IOCTLV_USBV0_CTRLMSG Ioctlv
 void BluetoothEmuDevice::ExecuteHCICommandMessage(const USB::V0CtrlMessage& ctrl_message)
 {
-  const u8* input = Memory::GetPointer(ctrl_message.data_address + 3);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u8* input = memory.GetPointer(ctrl_message.data_address + 3);
 
   SCommandMessage msg;
-  std::memcpy(&msg, Memory::GetPointer(ctrl_message.data_address), sizeof(msg));
+  std::memcpy(&msg, memory.GetPointer(ctrl_message.data_address), sizeof(msg));
 
   const u16 ocf = HCI_OCF(msg.Opcode);
   const u16 ogf = HCI_OGF(msg.Opcode);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -28,6 +28,7 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
+#include "Core/System.h"
 #include "VideoCommon/OnScreenDisplay.h"
 
 namespace IOS::HLE
@@ -212,9 +213,12 @@ std::optional<IPCReply> BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request
   // HCI commands to the Bluetooth adapter
   case USB::IOCTLV_USBV0_CTRLMSG:
   {
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    
     std::lock_guard lk(m_transfers_mutex);
     auto cmd = std::make_unique<USB::V0CtrlMessage>(m_ios, request);
-    const u16 opcode = Common::swap16(Memory::Read_U16(cmd->data_address));
+    const u16 opcode = Common::swap16(memory.Read_U16(cmd->data_address));
     if (opcode == HCI_CMD_READ_BUFFER_SIZE)
     {
       m_fake_read_buffer_size_reply.Set();
@@ -230,7 +234,7 @@ std::optional<IPCReply> BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request
     {
       // Delete link key(s) from our own link key storage when the game tells the adapter to
       hci_delete_stored_link_key_cp delete_cmd;
-      Memory::CopyFromEmu(&delete_cmd, cmd->data_address, sizeof(delete_cmd));
+      memory.CopyFromEmu(&delete_cmd, cmd->data_address, sizeof(delete_cmd));
       if (delete_cmd.delete_all)
         m_link_keys.clear();
       else
@@ -239,7 +243,7 @@ std::optional<IPCReply> BluetoothRealDevice::IOCtlV(const IOCtlVRequest& request
     auto buffer = std::make_unique<u8[]>(cmd->length + LIBUSB_CONTROL_SETUP_SIZE);
     libusb_fill_control_setup(buffer.get(), cmd->request_type, cmd->request, cmd->value, cmd->index,
                               cmd->length);
-    Memory::CopyFromEmu(buffer.get() + LIBUSB_CONTROL_SETUP_SIZE, cmd->data_address, cmd->length);
+    memory.CopyFromEmu(buffer.get() + LIBUSB_CONTROL_SETUP_SIZE, cmd->data_address, cmd->length);
     libusb_transfer* transfer = libusb_alloc_transfer(0);
     transfer->flags |= LIBUSB_TRANSFER_FREE_TRANSFER;
     libusb_fill_control_transfer(transfer, m_handle, buffer.get(), nullptr, this, 0);
@@ -321,7 +325,8 @@ void BluetoothRealDevice::DoState(PointerWrap& p)
     p.SetVerifyMode();
     return;
   }
-
+  
+  Device::DoState(p);
   // Prevent the transfer callbacks from messing with m_current_transfers after we have started
   // writing a savestate. We cannot use a scoped lock here because DoState is called twice and
   // we would lose the lock between the two calls.
@@ -488,13 +493,16 @@ bool BluetoothRealDevice::SendHCIStoreLinkKeyCommand()
 
 void BluetoothRealDevice::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   SHCIEventCommand hci_event;
-  Memory::CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
+  memory.CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
   hci_event.EventType = HCI_EVENT_COMMAND_COMPL;
   hci_event.PayloadLength = sizeof(SHCIEventCommand) - 2;
   hci_event.PacketIndicator = 0x01;
   hci_event.Opcode = m_fake_vendor_command_reply_opcode;
-  Memory::CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
+  memory.CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
   m_ios.EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event)));
 }
 
@@ -505,13 +513,16 @@ void BluetoothRealDevice::FakeVendorCommandReply(USB::V0IntrMessage& ctrl)
 // (including Wiimote disconnects and "event mismatch" warning messages).
 void BluetoothRealDevice::FakeReadBufferSizeReply(USB::V0IntrMessage& ctrl)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   SHCIEventCommand hci_event;
-  Memory::CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
+  memory.CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
   hci_event.EventType = HCI_EVENT_COMMAND_COMPL;
   hci_event.PayloadLength = sizeof(SHCIEventCommand) - 2 + sizeof(hci_read_buffer_size_rp);
   hci_event.PacketIndicator = 0x01;
   hci_event.Opcode = HCI_CMD_READ_BUFFER_SIZE;
-  Memory::CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
+  memory.CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
 
   hci_read_buffer_size_rp reply;
   reply.status = 0x00;
@@ -519,19 +530,22 @@ void BluetoothRealDevice::FakeReadBufferSizeReply(USB::V0IntrMessage& ctrl)
   reply.num_acl_pkts = ACL_PKT_NUM;
   reply.max_sco_size = SCO_PKT_SIZE;
   reply.num_sco_pkts = SCO_PKT_NUM;
-  Memory::CopyToEmu(ctrl.data_address + sizeof(hci_event), &reply, sizeof(reply));
+  memory.CopyToEmu(ctrl.data_address + sizeof(hci_event), &reply, sizeof(reply));
   m_ios.EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event) + sizeof(reply)));
 }
 
 void BluetoothRealDevice::FakeSyncButtonEvent(USB::V0IntrMessage& ctrl, const u8* payload,
                                               const u8 size)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   hci_event_hdr_t hci_event;
-  Memory::CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
+  memory.CopyFromEmu(&hci_event, ctrl.data_address, sizeof(hci_event));
   hci_event.event = HCI_EVENT_VENDOR;
   hci_event.length = size;
-  Memory::CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
-  Memory::CopyToEmu(ctrl.data_address + sizeof(hci_event), payload, size);
+  memory.CopyToEmu(ctrl.data_address, &hci_event, sizeof(hci_event));
+  memory.CopyToEmu(ctrl.data_address + sizeof(hci_event), payload, size);
   m_ios.EnqueueIPCReply(ctrl.ios_request, static_cast<s32>(sizeof(hci_event) + size));
 }
 

--- a/Source/Core/Core/IOS/USB/Common.cpp
+++ b/Source/Core/Core/IOS/USB/Common.cpp
@@ -11,6 +11,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Swap.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace IOS::HLE::USB
 {
@@ -18,14 +19,18 @@ std::unique_ptr<u8[]> TransferCommand::MakeBuffer(const size_t size) const
 {
   ASSERT_MSG(IOS_USB, data_address != 0, "Invalid data_address");
   auto buffer = std::make_unique<u8[]>(size);
-  Memory::CopyFromEmu(buffer.get(), data_address, size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyFromEmu(buffer.get(), data_address, size);
   return buffer;
 }
 
 void TransferCommand::FillBuffer(const u8* src, const size_t size) const
 {
   ASSERT_MSG(IOS_USB, size == 0 || data_address != 0, "Invalid data_address");
-  Memory::CopyToEmu(data_address, src, size);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyToEmu(data_address, src, size);
 }
 
 void TransferCommand::OnTransferComplete(s32 return_value) const
@@ -35,7 +40,9 @@ void TransferCommand::OnTransferComplete(s32 return_value) const
 
 void IsoMessage::SetPacketReturnValue(const size_t packet_num, const u16 return_value) const
 {
-  Memory::Write_U16(return_value, static_cast<u32>(packet_sizes_addr + packet_num * sizeof(u16)));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.Write_U16(return_value, static_cast<u32>(packet_sizes_addr + packet_num * sizeof(u16)));
 }
 
 Device::~Device() = default;

--- a/Source/Core/Core/IOS/USB/Host.cpp
+++ b/Source/Core/Core/IOS/USB/Host.cpp
@@ -55,6 +55,7 @@ void USBHost::UpdateWantDeterminism(const bool new_want_determinism)
 
 void USBHost::DoState(PointerWrap& p)
 {
+  Device::DoState(p);
   if (IsOpened() && p.IsReadMode())
   {
     // After a state has loaded, there may be insertion hooks for devices that were

--- a/Source/Core/Core/IOS/USB/LibusbDevice.cpp
+++ b/Source/Core/Core/IOS/USB/LibusbDevice.cpp
@@ -21,6 +21,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
 #include "Core/IOS/IOS.h"
+#include "Core/System.h"
 
 namespace IOS::HLE::USB
 {
@@ -247,7 +248,11 @@ int LibusbDevice::SubmitTransfer(std::unique_ptr<CtrlMessage> cmd)
   auto buffer = std::make_unique<u8[]>(size);
   libusb_fill_control_setup(buffer.get(), cmd->request_type, cmd->request, cmd->value, cmd->index,
                             cmd->length);
-  Memory::CopyFromEmu(buffer.get() + LIBUSB_CONTROL_SETUP_SIZE, cmd->data_address, cmd->length);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyFromEmu(buffer.get() + LIBUSB_CONTROL_SETUP_SIZE, cmd->data_address, cmd->length);
+  
   libusb_transfer* transfer = libusb_alloc_transfer(0);
   transfer->flags |= LIBUSB_TRANSFER_FREE_TRANSFER;
   libusb_fill_control_transfer(transfer, m_handle, buffer.release(), CtrlTransferCallback, this, 0);

--- a/Source/Core/Core/IOS/USB/OH0/OH0.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0.cpp
@@ -18,6 +18,7 @@
 #include "Core/IOS/USB/Common.h"
 #include "Core/IOS/USB/USBV0.h"
 #include "Core/IOS/VersionInfo.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -92,9 +93,12 @@ IPCReply OH0::CancelInsertionHook(const IOCtlRequest& request)
   if (!request.buffer_in || request.buffer_in_size != 4)
     return IPCReply(IPC_EINVAL);
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   // IOS assigns random IDs, but ours are simply the VID + PID (see RegisterInsertionHookWithID)
   TriggerHook(m_insertion_hooks,
-              {Memory::Read_U16(request.buffer_in), Memory::Read_U16(request.buffer_in + 2)},
+              {memory.Read_U16(request.buffer_in), memory.Read_U16(request.buffer_in + 2)},
               USB_ECANCELED);
   return IPCReply(IPC_SUCCESS);
 }
@@ -104,11 +108,14 @@ IPCReply OH0::GetDeviceList(const IOCtlVRequest& request) const
   if (!request.HasNumberOfValidVectors(2, 2))
     return IPCReply(IPC_EINVAL);
 
-  const u8 max_entries_count = Memory::Read_U8(request.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u8 max_entries_count = memory.Read_U8(request.in_vectors[0].address);
   if (request.io_vectors[1].size != max_entries_count * sizeof(DeviceEntry))
     return IPCReply(IPC_EINVAL);
 
-  const u8 interface_class = Memory::Read_U8(request.in_vectors[1].address);
+  const u8 interface_class = memory.Read_U8(request.in_vectors[1].address);
   u8 entries_count = 0;
   std::lock_guard lk(m_devices_mutex);
   for (const auto& device : m_devices)
@@ -122,9 +129,9 @@ IPCReply OH0::GetDeviceList(const IOCtlVRequest& request) const
     entry.unknown = 0;
     entry.vid = Common::swap16(device.second->GetVid());
     entry.pid = Common::swap16(device.second->GetPid());
-    Memory::CopyToEmu(request.io_vectors[1].address + 8 * entries_count++, &entry, 8);
+    memory.CopyToEmu(request.io_vectors[1].address + 8 * entries_count++, &entry, 8);
   }
-  Memory::Write_U8(entries_count, request.io_vectors[0].address);
+  memory.Write_U8(entries_count, request.io_vectors[0].address);
   return IPCReply(IPC_SUCCESS);
 }
 
@@ -133,8 +140,11 @@ IPCReply OH0::GetRhDesca(const IOCtlRequest& request) const
   if (!request.buffer_out || request.buffer_out_size != 4)
     return IPCReply(IPC_EINVAL);
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   // Based on a hardware test, this ioctl seems to return a constant value
-  Memory::Write_U32(0x02000302, request.buffer_out);
+  memory.Write_U32(0x02000302, request.buffer_out);
   request.Dump(GetDeviceName(), Common::Log::LogType::IOS_USB, Common::Log::LogLevel::LWARNING);
   return IPCReply(IPC_SUCCESS);
 }
@@ -174,8 +184,11 @@ std::optional<IPCReply> OH0::RegisterInsertionHook(const IOCtlVRequest& request)
   if (!request.HasNumberOfValidVectors(2, 0))
     return IPCReply(IPC_EINVAL);
 
-  const u16 vid = Memory::Read_U16(request.in_vectors[0].address);
-  const u16 pid = Memory::Read_U16(request.in_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u16 vid = memory.Read_U16(request.in_vectors[0].address);
+  const u16 pid = memory.Read_U16(request.in_vectors[1].address);
   if (HasDeviceWithVidPid(vid, pid))
     return IPCReply(IPC_SUCCESS);
 
@@ -190,16 +203,19 @@ std::optional<IPCReply> OH0::RegisterInsertionHookWithID(const IOCtlVRequest& re
   if (!request.HasNumberOfValidVectors(3, 1))
     return IPCReply(IPC_EINVAL);
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   std::lock_guard lock{m_hooks_mutex};
-  const u16 vid = Memory::Read_U16(request.in_vectors[0].address);
-  const u16 pid = Memory::Read_U16(request.in_vectors[1].address);
-  const bool trigger_only_for_new_device = Memory::Read_U8(request.in_vectors[2].address) == 1;
+  const u16 vid = memory.Read_U16(request.in_vectors[0].address);
+  const u16 pid = memory.Read_U16(request.in_vectors[1].address);
+  const bool trigger_only_for_new_device = memory.Read_U8(request.in_vectors[2].address) == 1;
   if (!trigger_only_for_new_device && HasDeviceWithVidPid(vid, pid))
     return IPCReply(IPC_SUCCESS);
   // TODO: figure out whether IOS allows more than one hook.
   m_insertion_hooks.insert({{vid, pid}, request.address});
   // The output vector is overwritten with an ID to use with ioctl 31 for cancelling the hook.
-  Memory::Write_U32(vid << 16 | pid, request.io_vectors[0].address);
+  memory.Write_U32(vid << 16 | pid, request.io_vectors[0].address);
   return std::nullopt;
 }
 
@@ -316,25 +332,28 @@ std::optional<IPCReply> OH0::DeviceIOCtlV(const u64 device_id, const IOCtlVReque
 
 s32 OH0::SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   switch (ioctlv.request)
   {
   case USB::IOCTLV_USBV0_CTRLMSG:
     if (!ioctlv.HasNumberOfValidVectors(6, 1) ||
-        Common::swap16(Memory::Read_U16(ioctlv.in_vectors[4].address)) != ioctlv.io_vectors[0].size)
+        Common::swap16(memory.Read_U16(ioctlv.in_vectors[4].address)) != ioctlv.io_vectors[0].size)
       return IPC_EINVAL;
     return device.SubmitTransfer(std::make_unique<USB::V0CtrlMessage>(m_ios, ioctlv));
 
   case USB::IOCTLV_USBV0_BLKMSG:
   case USB::IOCTLV_USBV0_LBLKMSG:
     if (!ioctlv.HasNumberOfValidVectors(2, 1) ||
-        Memory::Read_U16(ioctlv.in_vectors[1].address) != ioctlv.io_vectors[0].size)
+        memory.Read_U16(ioctlv.in_vectors[1].address) != ioctlv.io_vectors[0].size)
       return IPC_EINVAL;
     return device.SubmitTransfer(std::make_unique<USB::V0BulkMessage>(
         m_ios, ioctlv, ioctlv.request == USB::IOCTLV_USBV0_LBLKMSG));
 
   case USB::IOCTLV_USBV0_INTRMSG:
     if (!ioctlv.HasNumberOfValidVectors(2, 1) ||
-        Memory::Read_U16(ioctlv.in_vectors[1].address) != ioctlv.io_vectors[0].size)
+        memory.Read_U16(ioctlv.in_vectors[1].address) != ioctlv.io_vectors[0].size)
       return IPC_EINVAL;
     return device.SubmitTransfer(std::make_unique<USB::V0IntrMessage>(m_ios, ioctlv));
 

--- a/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
+++ b/Source/Core/Core/IOS/USB/OH0/OH0Device.cpp
@@ -44,7 +44,7 @@ OH0Device::OH0Device(Kernel& ios, const std::string& name) : Device(ios, name, D
 void OH0Device::DoState(PointerWrap& p)
 {
   m_oh0 = std::static_pointer_cast<OH0>(GetIOS()->GetDeviceByName("/dev/usb/oh0"));
-  p.Do(m_name);
+  Device::DoState(p);
   p.Do(m_vid);
   p.Do(m_pid);
   p.Do(m_device_id);

--- a/Source/Core/Core/IOS/USB/USBV0.cpp
+++ b/Source/Core/Core/IOS/USB/USBV0.cpp
@@ -9,44 +9,53 @@
 #include "Common/Swap.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
+#include "Core/System.h"
 
 namespace IOS::HLE::USB
 {
 V0CtrlMessage::V0CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : CtrlMessage(ios, ioctlv, ioctlv.io_vectors[0].address)
 {
-  request_type = Memory::Read_U8(ioctlv.in_vectors[0].address);
-  request = Memory::Read_U8(ioctlv.in_vectors[1].address);
-  value = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[2].address));
-  index = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[3].address));
-  length = Common::swap16(Memory::Read_U16(ioctlv.in_vectors[4].address));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  request_type = memory.Read_U8(ioctlv.in_vectors[0].address);
+  request = memory.Read_U8(ioctlv.in_vectors[1].address);
+  value = Common::swap16(memory.Read_U16(ioctlv.in_vectors[2].address));
+  index = Common::swap16(memory.Read_U16(ioctlv.in_vectors[3].address));
+  length = Common::swap16(memory.Read_U16(ioctlv.in_vectors[4].address));
 }
 
 V0BulkMessage::V0BulkMessage(Kernel& ios, const IOCtlVRequest& ioctlv, bool long_length)
     : BulkMessage(ios, ioctlv, ioctlv.io_vectors[0].address)
 {
-  endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  endpoint = memory.Read_U8(ioctlv.in_vectors[0].address);
   if (long_length)
-    length = Memory::Read_U32(ioctlv.in_vectors[1].address);
+    length = memory.Read_U32(ioctlv.in_vectors[1].address);
   else
-    length = Memory::Read_U16(ioctlv.in_vectors[1].address);
+    length = memory.Read_U16(ioctlv.in_vectors[1].address);
 }
 
 V0IntrMessage::V0IntrMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : IntrMessage(ios, ioctlv, ioctlv.io_vectors[0].address)
 {
-  endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address);
-  length = Memory::Read_U16(ioctlv.in_vectors[1].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  endpoint = memory.Read_U8(ioctlv.in_vectors[0].address);
+  length = memory.Read_U16(ioctlv.in_vectors[1].address);
 }
 
 V0IsoMessage::V0IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : IsoMessage(ios, ioctlv, ioctlv.io_vectors[1].address)
 {
-  endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address);
-  length = Memory::Read_U16(ioctlv.in_vectors[1].address);
-  num_packets = Memory::Read_U8(ioctlv.in_vectors[2].address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  endpoint = memory.Read_U8(ioctlv.in_vectors[0].address);
+  length = memory.Read_U16(ioctlv.in_vectors[1].address);
+  num_packets = memory.Read_U8(ioctlv.in_vectors[2].address);
   packet_sizes_addr = ioctlv.io_vectors[0].address;
   for (size_t i = 0; i < num_packets; ++i)
-    packet_sizes.push_back(Memory::Read_U16(static_cast<u32>(packet_sizes_addr + i * sizeof(u16))));
+    packet_sizes.push_back(memory.Read_U16(static_cast<u32>(packet_sizes_addr + i * sizeof(u16))));
 }
 }  // namespace IOS::HLE::USB

--- a/Source/Core/Core/IOS/USB/USBV4.cpp
+++ b/Source/Core/Core/IOS/USB/USBV4.cpp
@@ -12,6 +12,7 @@
 #include "Common/Swap.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/Device.h"
+#include "Core/System.h"
 
 namespace IOS::HLE::USB
 {
@@ -47,8 +48,11 @@ struct HIDRequest
 
 V4CtrlMessage::V4CtrlMessage(Kernel& ios, const IOCtlRequest& ioctl) : CtrlMessage(ios, ioctl, 0)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   HIDRequest hid_request;
-  Memory::CopyFromEmu(&hid_request, ioctl.buffer_in, sizeof(hid_request));
+  memory.CopyFromEmu(&hid_request, ioctl.buffer_in, sizeof(hid_request));
   request_type = hid_request.control.bmRequestType;
   request = hid_request.control.bmRequest;
   value = Common::swap16(hid_request.control.wValue);
@@ -63,8 +67,11 @@ V4CtrlMessage::V4CtrlMessage(Kernel& ios, const IOCtlRequest& ioctl) : CtrlMessa
 V4GetUSStringMessage::V4GetUSStringMessage(Kernel& ios, const IOCtlRequest& ioctl)
     : CtrlMessage(ios, ioctl, 0)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   HIDRequest hid_request;
-  Memory::CopyFromEmu(&hid_request, ioctl.buffer_in, sizeof(hid_request));
+  memory.CopyFromEmu(&hid_request, ioctl.buffer_in, sizeof(hid_request));
   request_type = 0x80;
   request = REQUEST_GET_DESCRIPTOR;
   value = (0x03 << 8) | hid_request.string.bIndex;
@@ -75,16 +82,22 @@ V4GetUSStringMessage::V4GetUSStringMessage(Kernel& ios, const IOCtlRequest& ioct
 
 void V4GetUSStringMessage::OnTransferComplete(s32 return_value) const
 {
-  std::string message = Memory::GetString(data_address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  std::string message = memory.GetString(data_address);
   std::replace_if(message.begin(), message.end(), std::not_fn(IsPrintableCharacter), '?');
-  Memory::CopyToEmu(data_address, message.c_str(), message.size());
+  memory.CopyToEmu(data_address, message.c_str(), message.size());
   TransferCommand::OnTransferComplete(return_value);
 }
 
 V4IntrMessage::V4IntrMessage(Kernel& ios, const IOCtlRequest& ioctl) : IntrMessage(ios, ioctl, 0)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   HIDRequest hid_request;
-  Memory::CopyFromEmu(&hid_request, ioctl.buffer_in, sizeof(hid_request));
+  memory.CopyFromEmu(&hid_request, ioctl.buffer_in, sizeof(hid_request));
   length = Common::swap32(hid_request.interrupt.length);
   endpoint = static_cast<u8>(Common::swap32(hid_request.interrupt.endpoint));
   data_address = Common::swap32(hid_request.data_addr);

--- a/Source/Core/Core/IOS/USB/USBV5.cpp
+++ b/Source/Core/Core/IOS/USB/USBV5.cpp
@@ -13,6 +13,7 @@
 #include "Common/Swap.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -21,37 +22,45 @@ namespace USB
 V5CtrlMessage::V5CtrlMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : CtrlMessage(ios, ioctlv, ioctlv.GetVector(1)->address)
 {
-  request_type = Memory::Read_U8(ioctlv.in_vectors[0].address + 8);
-  request = Memory::Read_U8(ioctlv.in_vectors[0].address + 9);
-  value = Memory::Read_U16(ioctlv.in_vectors[0].address + 10);
-  index = Memory::Read_U16(ioctlv.in_vectors[0].address + 12);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  request_type = memory.Read_U8(ioctlv.in_vectors[0].address + 8);
+  request = memory.Read_U8(ioctlv.in_vectors[0].address + 9);
+  value = memory.Read_U16(ioctlv.in_vectors[0].address + 10);
+  index = memory.Read_U16(ioctlv.in_vectors[0].address + 12);
   length = static_cast<u16>(ioctlv.GetVector(1)->size);
 }
 
 V5BulkMessage::V5BulkMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : BulkMessage(ios, ioctlv, ioctlv.GetVector(1)->address)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   length = ioctlv.GetVector(1)->size;
-  endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address + 18);
+  endpoint = memory.Read_U8(ioctlv.in_vectors[0].address + 18);
 }
 
 V5IntrMessage::V5IntrMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : IntrMessage(ios, ioctlv, ioctlv.GetVector(1)->address)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
   length = ioctlv.GetVector(1)->size;
-  endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address + 14);
+  endpoint = memory.Read_U8(ioctlv.in_vectors[0].address + 14);
 }
 
 V5IsoMessage::V5IsoMessage(Kernel& ios, const IOCtlVRequest& ioctlv)
     : IsoMessage(ios, ioctlv, ioctlv.GetVector(2)->address)
 {
-  num_packets = Memory::Read_U8(ioctlv.in_vectors[0].address + 16);
-  endpoint = Memory::Read_U8(ioctlv.in_vectors[0].address + 17);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  num_packets = memory.Read_U8(ioctlv.in_vectors[0].address + 16);
+  endpoint = memory.Read_U8(ioctlv.in_vectors[0].address + 17);
   packet_sizes_addr = ioctlv.GetVector(1)->address;
   u32 total_packet_size = 0;
   for (size_t i = 0; i < num_packets; ++i)
   {
-    const u32 packet_size = Memory::Read_U16(static_cast<u32>(packet_sizes_addr + i * sizeof(u16)));
+    const u32 packet_size = memory.Read_U16(static_cast<u32>(packet_sizes_addr + i * sizeof(u16)));
     packet_sizes.push_back(packet_size);
     total_packet_size += packet_size;
   }
@@ -99,8 +108,10 @@ void USBV5ResourceManager::DoState(PointerWrap& p)
 
 USBV5ResourceManager::USBV5Device* USBV5ResourceManager::GetUSBV5Device(u32 in_buffer)
 {
-  const u8 index = Memory::Read_U8(in_buffer + offsetof(DeviceID, index));
-  const u16 number = Memory::Read_U16(in_buffer + offsetof(DeviceID, number));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const u8 index = memory.Read_U8(in_buffer + offsetof(DeviceID, index));
+  const u16 number = memory.Read_U16(in_buffer + offsetof(DeviceID, number));
 
   if (index >= m_usbv5_devices.size())
     return nullptr;
@@ -135,7 +146,9 @@ IPCReply USBV5ResourceManager::SetAlternateSetting(USBV5Device& device, const IO
   if (!host_device->AttachAndChangeInterface(device.interface_number))
     return IPCReply(-1);
 
-  const u8 alt_setting = Memory::Read_U8(request.buffer_in + 2 * sizeof(s32));
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const u8 alt_setting = memory.Read_U8(request.buffer_in + 2 * sizeof(s32));
 
   const bool success = host_device->SetAltSetting(alt_setting) == 0;
   return IPCReply(success ? IPC_SUCCESS : IPC_EINVAL);
@@ -160,8 +173,11 @@ IPCReply USBV5ResourceManager::Shutdown(const IOCtlRequest& request)
 
 IPCReply USBV5ResourceManager::SuspendResume(USBV5Device& device, const IOCtlRequest& request)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   const auto host_device = GetDeviceById(device.host_id);
-  const s32 resumed = Memory::Read_U32(request.buffer_in + 8);
+  const s32 resumed = memory.Read_U32(request.buffer_in + 8);
 
   // Note: this is unimplemented because there's no easy way to do this in a
   // platform-independant way (libusb does not support power management).
@@ -232,6 +248,9 @@ void USBV5ResourceManager::TriggerDeviceChangeReply()
     return;
   }
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   std::lock_guard lock{m_usbv5_devices_mutex};
   u8 num_devices = 0;
   for (auto it = m_usbv5_devices.crbegin(); it != m_usbv5_devices.crend(); ++it)
@@ -264,8 +283,8 @@ void USBV5ResourceManager::TriggerDeviceChangeReply()
     entry.interface_number = usbv5_device.interface_number;
     entry.num_altsettings = device->GetNumberOfAltSettings(entry.interface_number);
 
-    Memory::CopyToEmu(m_devicechange_hook_request->buffer_out + sizeof(entry) * num_devices, &entry,
-                      sizeof(entry));
+    memory.CopyToEmu(m_devicechange_hook_request->buffer_out + sizeof(entry) * num_devices, &entry,
+                     sizeof(entry));
     ++num_devices;
   }
 

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -13,6 +13,7 @@
 #include "Core/Config/MainSettings.h"
 #include "Core/Core.h"  // Local core functions
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 #include "InputCommon/ControlReference/ControlReference.h"  // For background input check
 
 #ifdef _WIN32
@@ -213,7 +214,9 @@ std::optional<IPCReply> USB_KBD::IOCtl(const IOCtlRequest& request)
   if (Config::Get(Config::MAIN_WII_KEYBOARD) && !Core::WantsDeterminism() &&
       ControlReference::GetInputGate() && !m_message_queue.empty())
   {
-    Memory::CopyToEmu(request.buffer_out, &m_message_queue.front(), sizeof(MessageData));
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    memory.CopyToEmu(request.buffer_out, &m_message_queue.front(), sizeof(MessageData));
     m_message_queue.pop();
   }
   return IPCReply(IPC_SUCCESS);

--- a/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
+++ b/Source/Core/Core/IOS/USB/USB_VEN/VEN.cpp
@@ -12,6 +12,7 @@
 #include "Common/Logging/Log.h"
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/USB/Common.h"
+#include "Core/System.h"
 
 namespace IOS::HLE
 {
@@ -24,11 +25,14 @@ USB_VEN::~USB_VEN()
 
 std::optional<IPCReply> USB_VEN::IOCtl(const IOCtlRequest& request)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
   request.Log(GetDeviceName(), Common::Log::LogType::IOS_USB);
   switch (request.request)
   {
   case USB::IOCTL_USBV5_GETVERSION:
-    Memory::Write_U32(USBV5_VERSION, request.buffer_out);
+    memory.Write_U32(USBV5_VERSION, request.buffer_out);
     return IPCReply(IPC_SUCCESS);
   case USB::IOCTL_USBV5_GETDEVICECHANGE:
     return GetDeviceChange(request);
@@ -110,7 +114,10 @@ s32 USB_VEN::SubmitTransfer(USB::Device& device, const IOCtlVRequest& ioctlv)
 
 IPCReply USB_VEN::CancelEndpoint(USBV5Device& device, const IOCtlRequest& request)
 {
-  const u8 endpoint = Memory::Read_U8(request.buffer_in + 8);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  const u8 endpoint = memory.Read_U8(request.buffer_in + 8);
   // IPC_EINVAL (-4) is returned when no transfer was cancelled.
   if (GetDeviceById(device.host_id)->CancelTransfer(endpoint) < 0)
     return IPCReply(IPC_EINVAL);
@@ -122,21 +129,24 @@ IPCReply USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request
   if (request.buffer_out == 0 || request.buffer_out_size != 0xc0)
     return IPCReply(IPC_EINVAL);
 
-  const std::shared_ptr<USB::Device> host_device = GetDeviceById(device.host_id);
-  const u8 alt_setting = Memory::Read_U8(request.buffer_in + 8);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
-  Memory::Memset(request.buffer_out, 0, request.buffer_out_size);
-  Memory::Write_U32(Memory::Read_U32(request.buffer_in), request.buffer_out);
-  Memory::Write_U32(1, request.buffer_out + 4);
+  const std::shared_ptr<USB::Device> host_device = GetDeviceById(device.host_id);
+  const u8 alt_setting = memory.Read_U8(request.buffer_in + 8);
+
+  memory.Memset(request.buffer_out, 0, request.buffer_out_size);
+  memory.Write_U32(memory.Read_U32(request.buffer_in), request.buffer_out);
+  memory.Write_U32(1, request.buffer_out + 4);
 
   USB::DeviceDescriptor device_descriptor = host_device->GetDeviceDescriptor();
   device_descriptor.Swap();
-  Memory::CopyToEmu(request.buffer_out + 20, &device_descriptor, sizeof(device_descriptor));
+  memory.CopyToEmu(request.buffer_out + 20, &device_descriptor, sizeof(device_descriptor));
 
   // VEN only cares about the first configuration.
   USB::ConfigDescriptor config_descriptor = host_device->GetConfigurations()[0];
   config_descriptor.Swap();
-  Memory::CopyToEmu(request.buffer_out + 40, &config_descriptor, sizeof(config_descriptor));
+  memory.CopyToEmu(request.buffer_out + 40, &config_descriptor, sizeof(config_descriptor));
 
   std::vector<USB::InterfaceDescriptor> interfaces = host_device->GetInterfaces(0);
   auto it = std::find_if(interfaces.begin(), interfaces.end(),
@@ -147,14 +157,14 @@ IPCReply USB_VEN::GetDeviceInfo(USBV5Device& device, const IOCtlRequest& request
   if (it == interfaces.end())
     return IPCReply(IPC_EINVAL);
   it->Swap();
-  Memory::CopyToEmu(request.buffer_out + 52, &*it, sizeof(*it));
+  memory.CopyToEmu(request.buffer_out + 52, &*it, sizeof(*it));
 
   auto endpoints = host_device->GetEndpoints(0, it->bInterfaceNumber, it->bAlternateSetting);
   for (size_t i = 0; i < endpoints.size(); ++i)
   {
     endpoints[i].Swap();
-    Memory::CopyToEmu(request.buffer_out + 64 + 8 * static_cast<u8>(i), &endpoints[i],
-                      sizeof(endpoints[i]));
+    memory.CopyToEmu(request.buffer_out + 64 + 8 * static_cast<u8>(i), &endpoints[i],
+                     sizeof(endpoints[i]));
   }
 
   return IPCReply(IPC_SUCCESS);

--- a/Source/Core/Core/PowerPC/GDBStub.cpp
+++ b/Source/Core/Core/PowerPC/GDBStub.cpp
@@ -809,7 +809,10 @@ static void ReadMemory()
 
   if (!PowerPC::HostIsRAMAddress(addr))
     return SendReply("E00");
-  u8* data = Memory::GetPointer(addr);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  u8* data = memory.GetPointer(addr);
   Mem2hex(reply, data, len);
   reply[len * 2] = '\0';
   SendReply((char*)reply);
@@ -833,7 +836,10 @@ static void WriteMemory()
 
   if (!PowerPC::HostIsRAMAddress(addr))
     return SendReply("E00");
-  u8* dst = Memory::GetPointer(addr);
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  u8* dst = memory.GetPointer(addr);
   Hex2mem(dst, s_cmd_bfr + i + 1, len);
   SendReply("OK");
 }

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -223,13 +223,16 @@ bool Jit64::HandleFault(uintptr_t access_address, SContext* ctx)
   // This generates some fairly heavy trampolines, but it doesn't really hurt.
   // Only instructions that access I/O will get these, and there won't be that
   // many of them in a typical program/game.
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   // TODO: do we properly handle off-the-end?
-  const auto base_ptr = reinterpret_cast<uintptr_t>(Memory::physical_base);
+  const auto base_ptr = reinterpret_cast<uintptr_t>(memory.GetPhysicalBase());
   if (access_address >= base_ptr && access_address < base_ptr + 0x100010000)
     return BackPatch(static_cast<u32>(access_address - base_ptr), ctx);
 
-  const auto logical_base_ptr = reinterpret_cast<uintptr_t>(Memory::logical_base);
+  const auto logical_base_ptr = reinterpret_cast<uintptr_t>(memory.GetLogicalBase());
   if (access_address >= logical_base_ptr && access_address < logical_base_ptr + 0x100010000)
     return BackPatch(static_cast<u32>(access_address - logical_base_ptr), ctx);
 
@@ -330,7 +333,10 @@ void Jit64::Init()
 {
   EnableBlockLink();
 
-  jo.fastmem_arena = m_fastmem_enabled && Memory::InitFastmemArena();
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  jo.fastmem_arena = m_fastmem_enabled && memory.InitFastmemArena();
   jo.optimizeGatherPipe = true;
   jo.accurateSinglePrecision = true;
   UpdateMemoryAndExceptionOptions();
@@ -404,7 +410,9 @@ void Jit64::Shutdown()
   FreeStack();
   FreeCodeSpace();
 
-  Memory::ShutdownFastmemArena();
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.ShutdownFastmemArena();
 
   blocks.Shutdown();
   m_far_code.Shutdown();

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -16,6 +16,7 @@
 #include "Core/PowerPC/Jit64/Jit.h"
 #include "Core/PowerPC/Jit64Common/Jit64PowerPCState.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 using namespace Gen;
 
@@ -102,6 +103,9 @@ void Jit64AsmRoutineManager::Generate()
 
   dispatcher_no_check = GetCodePtr();
 
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   // The following is a translation of JitBaseBlockCache::Dispatch into assembly.
   const bool assembly_dispatcher = true;
   if (assembly_dispatcher)
@@ -141,10 +145,10 @@ void Jit64AsmRoutineManager::Generate()
     // Switch to the correct memory base, in case MSR.DR has changed.
     TEST(32, PPCSTATE(msr), Imm32(1 << (31 - 27)));
     FixupBranch physmem = J_CC(CC_Z);
-    MOV(64, R(RMEM), ImmPtr(Memory::logical_base));
+    MOV(64, R(RMEM), ImmPtr(memory.GetLogicalBase()));
     JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlockData, normalEntry))));
     SetJumpTarget(physmem);
-    MOV(64, R(RMEM), ImmPtr(Memory::physical_base));
+    MOV(64, R(RMEM), ImmPtr(memory.GetPhysicalBase()));
     JMPptr(MDisp(RSCRATCH, static_cast<s32>(offsetof(JitBlockData, normalEntry))));
 
     SetJumpTarget(not_found);
@@ -165,10 +169,10 @@ void Jit64AsmRoutineManager::Generate()
   // Switch to the correct memory base, in case MSR.DR has changed.
   TEST(32, PPCSTATE(msr), Imm32(1 << (31 - 27)));
   FixupBranch physmem = J_CC(CC_Z);
-  MOV(64, R(RMEM), ImmPtr(Memory::logical_base));
+  MOV(64, R(RMEM), ImmPtr(memory.GetLogicalBase()));
   JMPptr(R(ABI_RETURN));
   SetJumpTarget(physmem);
-  MOV(64, R(RMEM), ImmPtr(Memory::physical_base));
+  MOV(64, R(RMEM), ImmPtr(memory.GetPhysicalBase()));
   JMPptr(R(ABI_RETURN));
 
   SetJumpTarget(no_block_available);

--- a/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
+++ b/Source/Core/Core/PowerPC/Jit64Common/EmuCodeBlock.cpp
@@ -442,7 +442,9 @@ void EmuCodeBlock::SafeLoadToRegImmediate(X64Reg reg_value, u32 address, int acc
   u32 mmioAddress = PowerPC::IsOptimizableMMIOAccess(address, accessSize);
   if (accessSize != 64 && mmioAddress)
   {
-    MMIOLoadToReg(Memory::mmio_mapping.get(), reg_value, registersInUse, mmioAddress, accessSize,
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    MMIOLoadToReg(memory.GetMMIOMapping(), reg_value, registersInUse, mmioAddress, accessSize,
                   signExtend);
     return;
   }

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -53,7 +53,10 @@ void JitArm64::Init()
   AllocCodeSpace(CODE_SIZE + child_code_size);
   AddChildCodeSpace(&m_far_code, child_code_size);
 
-  jo.fastmem_arena = m_fastmem_enabled && Memory::InitFastmemArena();
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  jo.fastmem_arena = m_fastmem_enabled && memory.InitFastmemArena();
   jo.enableBlocklink = true;
   jo.optimizeGatherPipe = true;
   UpdateMemoryAndExceptionOptions();
@@ -154,7 +157,9 @@ void JitArm64::ResetFreeMemoryRanges()
 
 void JitArm64::Shutdown()
 {
-  Memory::ShutdownFastmemArena();
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.ShutdownFastmemArena();
   FreeCodeSpace();
   blocks.Shutdown();
   FreeStack();

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_BackPatch.cpp
@@ -22,6 +22,7 @@
 #include "Core/PowerPC/JitArmCommon/BackPatch.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 using namespace Arm64Gen;
 
@@ -302,14 +303,17 @@ void JitArm64::EmitBackpatchRoutine(u32 flags, MemAccessMode mode, ARM64Reg RS, 
 
 bool JitArm64::HandleFastmemFault(uintptr_t access_address, SContext* ctx)
 {
-  if (!(access_address >= (uintptr_t)Memory::physical_base &&
-        access_address < (uintptr_t)Memory::physical_base + 0x100010000) &&
-      !(access_address >= (uintptr_t)Memory::logical_base &&
-        access_address < (uintptr_t)Memory::logical_base + 0x100010000))
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+
+  if (!(access_address >= (uintptr_t)memory.GetPhysicalBase() &&
+        access_address < (uintptr_t)memory.GetPhysicalBase() + 0x100010000) &&
+      !(access_address >= (uintptr_t)memory.GetLogicalBase() &&
+        access_address < (uintptr_t)memory.GetLogicalBase() + 0x100010000))
   {
     ERROR_LOG_FMT(DYNA_REC,
                   "Exception handler - access below memory space. PC: {:#018x} {:#018x} < {:#018x}",
-                  ctx->CTX_PC, access_address, (uintptr_t)Memory::physical_base);
+                  ctx->CTX_PC, access_address, (uintptr_t)memory.GetPhysicalBase());
     return false;
   }
 

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStore.cpp
@@ -20,6 +20,7 @@
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PPCTables.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 using namespace Arm64Gen;
 
@@ -144,8 +145,10 @@ void JitArm64::SafeLoadToReg(u32 dest, s32 addr, s32 offsetReg, u32 flags, s32 o
     regs_in_use[DecodeReg(ARM64Reg::W0)] = 0;
     regs_in_use[DecodeReg(ARM64Reg::W30)] = 0;
     regs_in_use[DecodeReg(dest_reg)] = 0;
-    MMIOLoadToReg(Memory::mmio_mapping.get(), this, &m_float_emit, regs_in_use, fprs_in_use,
-                  dest_reg, mmio_address, flags);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    MMIOLoadToReg(memory.GetMMIOMapping(), this, &m_float_emit, regs_in_use, fprs_in_use, dest_reg,
+                  mmio_address, flags);
     addr_reg_set = false;
   }
   else
@@ -316,8 +319,10 @@ void JitArm64::SafeStoreFromReg(s32 dest, u32 value, s32 regOffset, u32 flags, s
     regs_in_use[DecodeReg(ARM64Reg::W1)] = 0;
     regs_in_use[DecodeReg(ARM64Reg::W30)] = 0;
     regs_in_use[DecodeReg(RS)] = 0;
-    MMIOWriteRegToAddr(Memory::mmio_mapping.get(), this, &m_float_emit, regs_in_use, fprs_in_use,
-                       RS, mmio_address, flags);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    MMIOWriteRegToAddr(memory.GetMMIOMapping(), this, &m_float_emit, regs_in_use, fprs_in_use, RS,
+                       mmio_address, flags);
     addr_reg_set = false;
   }
   else

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -20,6 +20,7 @@
 #include "Core/PowerPC/JitCommon/JitCache.h"
 #include "Core/PowerPC/MMU.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 using namespace Arm64Gen;
 
@@ -87,16 +88,21 @@ void JitArm64::GenerateAsm()
   dispatcher_no_check = GetCodePtr();
 
   bool assembly_dispatcher = true;
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   if (assembly_dispatcher)
   {
     // set the mem_base based on MSR flags
     LDR(IndexType::Unsigned, ARM64Reg::W28, PPC_REG, PPCSTATE_OFF(msr));
     FixupBranch physmem = TBNZ(ARM64Reg::W28, 31 - 27);
-    MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::physical_base : Memory::physical_page_mappings_base);
+    MOVP2R(MEM_REG,
+           jo.fastmem_arena ? memory.GetPhysicalBase() : memory.GetPhysicalPageMappingsBase());
     FixupBranch membaseend = B();
     SetJumpTarget(physmem);
-    MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::logical_base : Memory::logical_page_mappings_base);
+    MOVP2R(MEM_REG,
+           jo.fastmem_arena ? memory.GetLogicalBase() : memory.GetLogicalPageMappingsBase());
     SetJumpTarget(membaseend);
 
     // iCache[(address >> 2) & iCache_Mask];
@@ -141,10 +147,11 @@ void JitArm64::GenerateAsm()
   // set the mem_base based on MSR flags and jump to next block.
   LDR(IndexType::Unsigned, ARM64Reg::W28, PPC_REG, PPCSTATE_OFF(msr));
   FixupBranch physmem = TBNZ(ARM64Reg::W28, 31 - 27);
-  MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::physical_base : Memory::physical_page_mappings_base);
+  MOVP2R(MEM_REG,
+         jo.fastmem_arena ? memory.GetPhysicalBase() : memory.GetPhysicalPageMappingsBase());
   BR(ARM64Reg::X0);
   SetJumpTarget(physmem);
-  MOVP2R(MEM_REG, jo.fastmem_arena ? Memory::logical_base : Memory::logical_page_mappings_base);
+  MOVP2R(MEM_REG, jo.fastmem_arena ? memory.GetLogicalBase() : memory.GetLogicalPageMappingsBase());
   BR(ARM64Reg::X0);
 
   // Call JIT

--- a/Source/Core/Core/PowerPC/PPCCache.cpp
+++ b/Source/Core/Core/PowerPC/PPCCache.cpp
@@ -12,6 +12,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/JitInterface.h"
 #include "Core/PowerPC/PowerPC.h"
+#include "Core/System.h"
 
 namespace PowerPC
 {
@@ -139,8 +140,11 @@ void InstructionCache::Invalidate(u32 addr)
 
 u32 InstructionCache::ReadInstruction(u32 addr)
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   if (!HID0.ICE || m_disable_icache)  // instruction cache is disabled
-    return Memory::Read_U32(addr);
+    return memory.Read_U32(addr);
   u32 set = (addr >> 5) & 0x7f;
   u32 tag = addr >> 12;
 
@@ -161,14 +165,14 @@ u32 InstructionCache::ReadInstruction(u32 addr)
   if (t == 0xff)  // load to the cache
   {
     if (HID0.ILOCK)  // instruction cache is locked
-      return Memory::Read_U32(addr);
+      return memory.Read_U32(addr);
     // select a way
     if (valid[set] != 0xff)
       t = s_way_from_valid[valid[set]];
     else
       t = s_way_from_plru[plru[set]];
     // load
-    Memory::CopyFromEmu(reinterpret_cast<u8*>(data[set][t].data()), (addr & ~0x1f), 32);
+    memory.CopyFromEmu(reinterpret_cast<u8*>(data[set][t].data()), (addr & ~0x1f), 32);
     if (valid[set] & (1 << t))
     {
       if (tags[set][t] & (ICACHE_VMEM_BIT >> 12))
@@ -191,7 +195,7 @@ u32 InstructionCache::ReadInstruction(u32 addr)
   // update plru
   plru[set] = (plru[set] & ~s_plru_mask[t]) | s_plru_value[t];
   const u32 res = Common::swap32(data[set][t][(addr >> 2) & 7]);
-  const u32 inmem = Memory::Read_U32(addr);
+  const u32 inmem = memory.Read_U32(addr);
   if (res != inmem)
   {
     INFO_LOG_FMT(POWERPC,

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -194,17 +194,19 @@ static void DoState(PointerWrap& p)
   }
 
   // Check to make sure the emulated memory sizes are the same as the savestate
-  u32 state_mem1_size = Memory::GetRamSizeReal();
-  u32 state_mem2_size = Memory::GetExRamSizeReal();
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  u32 state_mem1_size = memory.GetRamSizeReal();
+  u32 state_mem2_size = memory.GetExRamSizeReal();
   p.Do(state_mem1_size);
   p.Do(state_mem2_size);
-  if (state_mem1_size != Memory::GetRamSizeReal() || state_mem2_size != Memory::GetExRamSizeReal())
+  if (state_mem1_size != memory.GetRamSizeReal() || state_mem2_size != memory.GetExRamSizeReal())
   {
     OSD::AddMessage(fmt::format("Memory size mismatch!\n"
                                 "Current | MEM1 {:08X} ({:3}MB)    MEM2 {:08X} ({:3}MB)\n"
                                 "State   | MEM1 {:08X} ({:3}MB)    MEM2 {:08X} ({:3}MB)",
-                                Memory::GetRamSizeReal(), Memory::GetRamSizeReal() / 0x100000U,
-                                Memory::GetExRamSizeReal(), Memory::GetExRamSizeReal() / 0x100000U,
+                                memory.GetRamSizeReal(), memory.GetRamSizeReal() / 0x100000U,
+                                memory.GetExRamSizeReal(), memory.GetExRamSizeReal() / 0x100000U,
                                 state_mem1_size, state_mem1_size / 0x100000U, state_mem2_size,
                                 state_mem2_size / 0x100000U));
     p.SetMeasureMode();
@@ -225,7 +227,7 @@ static void DoState(PointerWrap& p)
   p.DoMarker("PowerPC");
   // CoreTiming needs to be restored before restoring Hardware because
   // the controller code might need to schedule an event if the controller has changed.
-  Core::System::GetInstance().GetCoreTiming().DoState(p);
+  system.GetCoreTiming().DoState(p);
   p.DoMarker("CoreTiming");
   HW::DoState(p);
   p.DoMarker("HW");

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -13,6 +13,7 @@
 #include "Core/HW/DVD/DVDInterface.h"
 #include "Core/HW/DVD/DVDThread.h"
 #include "Core/HW/EXI/EXI.h"
+#include "Core/HW/Memmap.h"
 #include "Core/HW/MemoryInterface.h"
 #include "Core/HW/SI/SI.h"
 #include "Core/HW/Sram.h"
@@ -34,6 +35,7 @@ struct System::Impl
   DVDInterface::DVDInterfaceState m_dvd_interface_state;
   DVDThread::DVDThreadState m_dvd_thread_state;
   ExpansionInterface::ExpansionInterfaceState m_expansion_interface_state;
+  Memory::MemoryManager m_memory;
   MemoryInterface::MemoryInterfaceState m_memory_interface_state;
   SerialInterface::SerialInterfaceState m_serial_interface_state;
   Sram m_sram;
@@ -116,6 +118,11 @@ DVDThread::DVDThreadState& System::GetDVDThreadState() const
 ExpansionInterface::ExpansionInterfaceState& System::GetExpansionInterfaceState() const
 {
   return m_impl->m_expansion_interface_state;
+}
+
+Memory::MemoryManager& System::GetMemory() const
+{
+  return m_impl->m_memory;
 }
 
 MemoryInterface::MemoryInterfaceState& System::GetMemoryInterfaceState() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -36,6 +36,10 @@ namespace ExpansionInterface
 {
 class ExpansionInterfaceState;
 };
+namespace Memory
+{
+class MemoryManager;
+};
 namespace MemoryInterface
 {
 class MemoryInterfaceState;
@@ -90,6 +94,7 @@ public:
   DVDInterface::DVDInterfaceState& GetDVDInterfaceState() const;
   DVDThread::DVDThreadState& GetDVDThreadState() const;
   ExpansionInterface::ExpansionInterfaceState& GetExpansionInterfaceState() const;
+  Memory::MemoryManager& GetMemory() const;
   MemoryInterface::MemoryInterfaceState& GetMemoryInterfaceState() const;
   SerialInterface::SerialInterfaceState& GetSerialInterfaceState() const;
   Sram& GetSRAM() const;

--- a/Source/Core/DiscIO/RiivolutionPatcher.cpp
+++ b/Source/Core/DiscIO/RiivolutionPatcher.cpp
@@ -18,6 +18,7 @@
 #include "Core/HW/Memmap.h"
 #include "Core/IOS/FS/FileSystem.h"
 #include "Core/PowerPC/MMU.h"
+#include "Core/System.h"
 #include "DiscIO/DirectoryBlob.h"
 #include "DiscIO/RiivolutionParser.h"
 
@@ -582,6 +583,9 @@ static void ApplyOcarinaMemoryPatch(const Patch& patch, const Memory& memory_pat
 
 void ApplyGeneralMemoryPatches(const std::vector<Patch>& patches)
 {
+  auto& system = Core::System::GetInstance();
+  auto& system_memory = system.GetMemory();
+  
   for (const auto& patch : patches)
   {
     for (const auto& memory : patch.m_memory_patches)
@@ -590,7 +594,7 @@ void ApplyGeneralMemoryPatches(const std::vector<Patch>& patches)
         continue;
 
       if (memory.m_search)
-        ApplySearchMemoryPatch(patch, memory, 0x80000000, ::Memory::GetRamSize());
+        ApplySearchMemoryPatch(patch, memory, 0x80000000, system_memory.GetRamSize());
       else
         ApplyMemoryPatch(patch, memory);
     }

--- a/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
+++ b/Source/Core/DolphinQt/CheatSearchFactoryWidget.cpp
@@ -23,6 +23,7 @@
 #include "Core/Core.h"
 #include "Core/HW/Memmap.h"
 #include "Core/PowerPC/MMU.h"
+#include "Core/System.h"
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
 #include "DolphinQt/QtUtils/NonDefaultQPushButton.h"
 
@@ -164,9 +165,11 @@ void CheatSearchFactoryWidget::OnNewSearchClicked()
       return;
     }
 
-    memory_ranges.emplace_back(0x80000000, Memory::GetRamSizeReal());
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    memory_ranges.emplace_back(0x80000000, memory.GetRamSizeReal());
     if (SConfig::GetInstance().bWii)
-      memory_ranges.emplace_back(0x90000000, Memory::GetExRamSizeReal());
+      memory_ranges.emplace_back(0x90000000, memory.GetExRamSizeReal());
     address_space = PowerPC::RequestedAddressSpace::Virtual;
   }
   else

--- a/Source/Core/DolphinQt/MenuBar.cpp
+++ b/Source/Core/DolphinQt/MenuBar.cpp
@@ -43,6 +43,7 @@
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/PowerPC/SignatureDB/SignatureDB.h"
 #include "Core/State.h"
+#include "Core/System.h"
 #include "Core/TitleDatabase.h"
 #include "Core/WiiUtils.h"
 
@@ -1199,15 +1200,21 @@ void MenuBar::ClearSymbols()
 
 void MenuBar::GenerateSymbolsFromAddress()
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   PPCAnalyst::FindFunctions(Memory::MEM1_BASE_ADDR,
-                            Memory::MEM1_BASE_ADDR + Memory::GetRamSizeReal(), &g_symbolDB);
+                            Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &g_symbolDB);
   emit NotifySymbolsUpdated();
 }
 
 void MenuBar::GenerateSymbolsFromSignatureDB()
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   PPCAnalyst::FindFunctions(Memory::MEM1_BASE_ADDR,
-                            Memory::MEM1_BASE_ADDR + Memory::GetRamSizeReal(), &g_symbolDB);
+                            Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &g_symbolDB);
   SignatureDB db(SignatureDB::HandlerType::DSY);
   if (db.Load(File::GetSysDirectory() + TOTALDB))
   {
@@ -1414,6 +1421,9 @@ RSOVector MenuBar::DetectRSOModules(ParallelProgressDialog& progress)
 
 void MenuBar::LoadSymbolMap()
 {
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  
   std::string existing_map_file, writable_map_file;
   bool map_exists = CBoot::FindMapFile(&existing_map_file, &writable_map_file);
 
@@ -1421,7 +1431,7 @@ void MenuBar::LoadSymbolMap()
   {
     g_symbolDB.Clear();
     PPCAnalyst::FindFunctions(Memory::MEM1_BASE_ADDR + 0x1300000,
-                              Memory::MEM1_BASE_ADDR + Memory::GetRamSizeReal(), &g_symbolDB);
+                             Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal(), &g_symbolDB);
     SignatureDB db(SignatureDB::HandlerType::DSY);
     if (db.Load(File::GetSysDirectory() + TOTALDB))
       db.Apply(&g_symbolDB);
@@ -1661,9 +1671,12 @@ void MenuBar::SearchInstruction()
 
   if (!good)
     return;
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   bool found = false;
-  for (u32 addr = Memory::MEM1_BASE_ADDR; addr < Memory::MEM1_BASE_ADDR + Memory::GetRamSizeReal();
+  for (u32 addr = Memory::MEM1_BASE_ADDR; addr < Memory::MEM1_BASE_ADDR + memory.GetRamSizeReal();
        addr += 4)
   {
     const auto ins_name =

--- a/Source/Core/UICommon/DiscordPresence.cpp
+++ b/Source/Core/UICommon/DiscordPresence.cpp
@@ -290,7 +290,9 @@ void UpdateDiscordPresence(int party_size, SecretType type, const std::string& s
     discord_presence.smallImageText = "Dolphin is an emulator for the GameCube and the Wii.";
   }
   discord_presence.details = title.empty() ? "Not in-game" : title.c_str();
-  discord_presence.startTimestamp = std::time(nullptr);
+  discord_presence.startTimestamp = std::chrono::duration_cast<std::chrono::seconds>(
+                                        std::chrono::system_clock::now().time_since_epoch())
+                                        .count();
 
   if (party_size > 0)
   {

--- a/Source/Core/VideoBackends/Software/TextureSampler.cpp
+++ b/Source/Core/VideoBackends/Software/TextureSampler.cpp
@@ -9,6 +9,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/MsgHandler.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/TextureDecoder.h"
@@ -132,8 +133,11 @@ void SampleMip(s32 s, s32 t, s32 mip, bool linear, u8 texmap, u8* sample)
   }
   else
   {
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    
     const u32 imageBase = texUnit.texImage3.image_base << 5;
-    imageSrc = Memory::GetPointer(imageBase);
+    imageSrc = memory.GetPointer(imageBase);
   }
 
   int image_width_minus_1 = ti0.width;

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -357,7 +357,9 @@ static void BPWritten(const BPCmd& bp)
     if (!SConfig::GetInstance().bWii)
       addr = addr & 0x01FFFFFF;
 
-    Memory::CopyFromEmu(texMem + tlutTMemAddr, addr, tlutXferCount);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    memory.CopyFromEmu(texMem + tlutTMemAddr, addr, tlutXferCount);
 
     if (OpcodeDecoder::g_record_fifo_data)
       FifoRecorder::GetInstance().UseMemory(addr, tlutXferCount, MemoryUpdate::TMEM);
@@ -549,11 +551,15 @@ static void BPWritten(const BPCmd& bp)
         if (tmem_addr_even + bytes_read > TMEM_SIZE)
           bytes_read = TMEM_SIZE - tmem_addr_even;
 
-        Memory::CopyFromEmu(texMem + tmem_addr_even, src_addr, bytes_read);
+        auto& system = Core::System::GetInstance();
+        auto& memory = system.GetMemory();
+        memory.CopyFromEmu(texMem + tmem_addr_even, src_addr, bytes_read);
       }
       else  // RGBA8 tiles (and CI14, but that might just be stupid libogc!)
       {
-        u8* src_ptr = Memory::GetPointer(src_addr);
+        auto& system = Core::System::GetInstance();
+        auto& memory = system.GetMemory();
+        u8* src_ptr = memory.GetPointer(src_addr);
 
         // AR and GB tiles are stored in separate TMEM banks => can't use a single memcpy for
         // everything

--- a/Source/Core/VideoCommon/Fifo.cpp
+++ b/Source/Core/VideoCommon/Fifo.cpp
@@ -270,7 +270,9 @@ static void ReadDataFromFifo(u32 readPtr)
     s_video_buffer_read_ptr = s_video_buffer;
   }
   // Copy new video instructions to s_video_buffer for future use in rendering the new picture
-  Memory::CopyFromEmu(s_video_buffer_write_ptr, readPtr, GPFifo::GATHER_PIPE_SIZE);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyFromEmu(s_video_buffer_write_ptr, readPtr, GPFifo::GATHER_PIPE_SIZE);
   s_video_buffer_write_ptr += GPFifo::GATHER_PIPE_SIZE;
 }
 
@@ -303,7 +305,9 @@ static void ReadDataFromFifoOnCPU(u32 readPtr)
       return;
     }
   }
-  Memory::CopyFromEmu(s_video_buffer_write_ptr, readPtr, GPFifo::GATHER_PIPE_SIZE);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  memory.CopyFromEmu(s_video_buffer_write_ptr, readPtr, GPFifo::GATHER_PIPE_SIZE);
   s_video_buffer_pp_read_ptr = OpcodeDecoder::RunFifo<true>(
       DataReader(s_video_buffer_pp_read_ptr, write_ptr + GPFifo::GATHER_PIPE_SIZE), nullptr);
   // This would have to be locked if the GPU thread didn't spin.

--- a/Source/Core/VideoCommon/OpcodeDecoding.cpp
+++ b/Source/Core/VideoCommon/OpcodeDecoding.cpp
@@ -152,7 +152,9 @@ public:
 
       if constexpr (is_preprocess)
       {
-        const u8* const start_address = Memory::GetPointer(address);
+        auto& system = Core::System::GetInstance();
+        auto& memory = system.GetMemory();
+        const u8* const start_address = memory.GetPointer(address);
 
         Fifo::PushFifoAuxBuffer(start_address, size);
 
@@ -166,11 +168,17 @@ public:
         const u8* start_address;
 
         if (Fifo::UseDeterministicGPUThread())
+        {
           start_address = static_cast<u8*>(Fifo::PopFifoAuxBuffer(size));
+        }
         else
-          start_address = Memory::GetPointer(address);
+        {
+          auto& system = Core::System::GetInstance();
+          auto& memory = system.GetMemory();
+          start_address = memory.GetPointer(address);
+        }
 
-        // Avoid the crash if Memory::GetPointer failed ..
+        // Avoid the crash if memory.GetPointer failed ..
         if (start_address != nullptr)
         {
           // temporarily swap dl and non-dl (small "hack" for the stats)

--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -31,6 +31,7 @@
 #include "Core/FifoPlayer/FifoPlayer.h"
 #include "Core/FifoPlayer/FifoRecorder.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 #include "VideoCommon/AbstractFramebuffer.h"
 #include "VideoCommon/AbstractStagingTexture.h"
@@ -1732,7 +1733,9 @@ TextureCacheBase::TCacheEntry*
 TextureCacheBase::GetXFBTexture(u32 address, u32 width, u32 height, u32 stride,
                                 MathUtil::Rectangle<int>* display_rect)
 {
-  const u8* src_data = Memory::GetPointer(address);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const u8* src_data = memory.GetPointer(address);
   if (!src_data)
   {
     ERROR_LOG_FMT(VIDEO, "Trying to load XFB texture from invalid address {:#010x}", address);
@@ -2107,7 +2110,9 @@ void TextureCacheBase::CopyRenderTargetToTexture(
       !(is_xfb_copy ? g_ActiveConfig.bSkipXFBCopyToRam : g_ActiveConfig.bSkipEFBCopyToRam) ||
       !copy_to_vram;
 
-  u8* dst = Memory::GetPointer(dstAddr);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  u8* dst = memory.GetPointer(dstAddr);
   if (dst == nullptr)
   {
     ERROR_LOG_FMT(VIDEO, "Trying to copy from EFB to invalid address {:#010x}", dstAddr);
@@ -2422,7 +2427,9 @@ void TextureCacheBase::WriteEFBCopyToRAM(u8* dst_ptr, u32 width, u32 height, u32
 void TextureCacheBase::FlushEFBCopy(TCacheEntry* entry)
 {
   // Copy from texture -> guest memory.
-  u8* const dst = Memory::GetPointer(entry->addr);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  u8* const dst = memory.GetPointer(entry->addr);
   WriteEFBCopyToRAM(dst, entry->pending_efb_copy_width, entry->pending_efb_copy_height,
                     entry->memory_stride, std::move(entry->pending_efb_copy));
 
@@ -3024,7 +3031,9 @@ u64 TextureCacheBase::TCacheEntry::CalculateHash() const
   const u32 hash_sample_size = HashSampleSize();
 
   // FIXME: textures from tmem won't get the correct hash.
-  u8* ptr = Memory::GetPointer(addr);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  u8* ptr = memory.GetPointer(addr);
   if (memory_stride == bytes_per_row)
   {
     return Common::GetHash64(ptr, size_in_bytes, hash_sample_size);

--- a/Source/Core/VideoCommon/TextureInfo.cpp
+++ b/Source/Core/VideoCommon/TextureInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "Common/Align.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/TextureDecoder.h"
 
@@ -44,7 +45,9 @@ TextureInfo TextureInfo::FromStage(u32 stage)
                        &texMem[tmem_address_even], mip_count);
   }
 
-  return TextureInfo(stage, Memory::GetPointer(address), tlut_ptr, address, texture_format,
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  return TextureInfo(stage, memory.GetPointer(address), tlut_ptr, address, texture_format,
                      tlut_format, width, height, false, nullptr, nullptr, mip_count);
 }
 

--- a/Source/Core/VideoCommon/VertexLoaderManager.cpp
+++ b/Source/Core/VideoCommon/VertexLoaderManager.cpp
@@ -18,6 +18,7 @@
 
 #include "Core/DolphinAnalytics.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 #include "VideoCommon/BPMemory.h"
 #include "VideoCommon/CPMemory.h"
@@ -80,6 +81,9 @@ void UpdateVertexArrayPointers()
   // Anything to update?
   if (!g_bases_dirty) [[likely]]
     return;
+  
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
 
   // Some games such as Burnout 2 can put invalid addresses into
   // the array base registers. (see issue 8591)
@@ -89,24 +93,24 @@ void UpdateVertexArrayPointers()
   // We also only update the array base if the vertex description states we are going to use it.
   if (IsIndexed(g_main_cp_state.vtx_desc.low.Position))
     cached_arraybases[CPArray::Position] =
-        Memory::GetPointer(g_main_cp_state.array_bases[CPArray::Position]);
+        memory.GetPointer(g_main_cp_state.array_bases[CPArray::Position]);
 
   if (IsIndexed(g_main_cp_state.vtx_desc.low.Normal))
     cached_arraybases[CPArray::Normal] =
-        Memory::GetPointer(g_main_cp_state.array_bases[CPArray::Normal]);
+        memory.GetPointer(g_main_cp_state.array_bases[CPArray::Normal]);
 
   for (u8 i = 0; i < g_main_cp_state.vtx_desc.low.Color.Size(); i++)
   {
     if (IsIndexed(g_main_cp_state.vtx_desc.low.Color[i]))
       cached_arraybases[CPArray::Color0 + i] =
-          Memory::GetPointer(g_main_cp_state.array_bases[CPArray::Color0 + i]);
+          memory.GetPointer(g_main_cp_state.array_bases[CPArray::Color0 + i]);
   }
 
   for (u8 i = 0; i < g_main_cp_state.vtx_desc.high.TexCoord.Size(); i++)
   {
     if (IsIndexed(g_main_cp_state.vtx_desc.high.TexCoord[i]))
       cached_arraybases[CPArray::TexCoord0 + i] =
-          Memory::GetPointer(g_main_cp_state.array_bases[CPArray::TexCoord0 + i]);
+          memory.GetPointer(g_main_cp_state.array_bases[CPArray::TexCoord0 + i]);
   }
 
   g_bases_dirty = false;

--- a/Source/Core/VideoCommon/XFStructs.cpp
+++ b/Source/Core/VideoCommon/XFStructs.cpp
@@ -10,6 +10,7 @@
 
 #include "Core/DolphinAnalytics.h"
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 #include "VideoCommon/CPMemory.h"
 #include "VideoCommon/Fifo.h"
@@ -262,8 +263,10 @@ void LoadIndexedXF(CPArray array, u32 index, u16 address, u8 size)
   }
   else
   {
-    newData = (u32*)Memory::GetPointer(g_main_cp_state.array_bases[array] +
-                                       g_main_cp_state.array_strides[array] * index);
+    auto& system = Core::System::GetInstance();
+    auto& memory = system.GetMemory();
+    newData = (u32*)memory.GetPointer(g_main_cp_state.array_bases[array] +
+                                      g_main_cp_state.array_strides[array] * index);
   }
   bool changed = false;
   for (u32 i = 0; i < size; ++i)
@@ -284,8 +287,10 @@ void LoadIndexedXF(CPArray array, u32 index, u16 address, u8 size)
 
 void PreprocessIndexedXF(CPArray array, u32 index, u16 address, u8 size)
 {
-  const u8* new_data = Memory::GetPointer(g_preprocess_cp_state.array_bases[array] +
-                                          g_preprocess_cp_state.array_strides[array] * index);
+  auto& system = Core::System::GetInstance();
+  auto& memory = system.GetMemory();
+  const u8* new_data = memory.GetPointer(g_preprocess_cp_state.array_bases[array] +
+                                         g_preprocess_cp_state.array_strides[array] * index);
 
   const size_t buf_size = size * sizeof(u32);
   Fifo::PushFifoAuxBuffer(new_data, buf_size);


### PR DESCRIPTION
[https://github.com/dolphin-emu/dolphin/pull/11320](https://github.com/dolphin-emu/dolphin/pull/11320)

This was a massive PR with many changes. While working on it, I found that some code changes from the official Dolphin repo were either synced partially or not at all. Thus this commit also contains changes from these PRs in an attempt to update the codebase as close to Dolphin official as possible.

IOS/ES: Add support for V1Ticket #11240 by noahpistilli
[https://github.com/dolphin-emu/dolphin/pull/11240](https://github.com/dolphin-emu/dolphin/pull/11240)
Commit - DolphinDevice: expose elapsed ms in GetSystemTime by shuffle2 from PR Timer improvements #10872
[https://github.com/dolphin-emu/dolphin/pull/10872/commits/49218f9695f5e894bbe843d20c76a02c5a5ee68d](https://github.com/dolphin-emu/dolphin/pull/10872/commits/49218f9695f5e894bbe843d20c76a02c5a5ee68d)
[https://github.com/dolphin-emu/dolphin/pull/10872](https://github.com/dolphin-emu/dolphin/pull/10872)
Add DolphinDevice::GetSystemTime to allow for accurate Unix timestamp generation #11269 by vabold
[https://github.com/dolphin-emu/dolphin/pull/11269](https://github.com/dolphin-emu/dolphin/pull/11269)
IOS: Simplify IOS::HLE::Device savestate method #11177 by Lobsterzelda
[https://github.com/dolphin-emu/dolphin/pull/11177](https://github.com/dolphin-emu/dolphin/pull/11177)


