### PR TITLE
Add VI Skip to MMJR2 Quick Menu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/QuickSettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/QuickSettingsFragment.java
@@ -173,6 +173,8 @@ public class QuickSettingsFragment extends Fragment implements SettingsFragmentV
             R.string.efb_copy_method, 0));
     sl.add(new CheckBoxSetting(context,BooleanSetting.GFX_HACK_DEFER_EFB_COPIES,
             R.string.defer_efb_copies, 0));
+    sl.add(new CheckBoxSetting(context, BooleanSetting.GFX_HACK_VI_SKIP, R.string.vi_skip,
+            R.string.vi_skip_description));
     //sl.add(new InvertedCheckBoxSetting(context, BooleanSetting.GFX_HACK_BBOX_ENABLE,R.string.disable_bbox, 0));
 
     mSettingsList = sl;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -54,7 +54,7 @@ public final class DirectoryInitialization
     directoryState.setValue(DirectoryInitializationState.INITIALIZING);
 
     // Can take a few seconds to run, so don't block UI thread.
-    ((Runnable) () -> init(context)).run();
+    new Thread(() -> init(context)).run();
   }
 
   private static void init(Context context)


### PR DESCRIPTION
This adds VBI Skip Hack to MMJR2 Quick Menu. It also reintroduces threaded Directory Initialization.