### PR TITLE
Use different user directory than MMJR2

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/utils/DirectoryInitialization.java
@@ -100,7 +100,7 @@ public final class DirectoryInitialization
       File externalPath = Environment.getExternalStorageDirectory();
       if (externalPath != null)
       {
-        userPath = externalPath.getAbsolutePath() + "/mmjr-revamp";
+        userPath = externalPath.getAbsolutePath() + "/mmjr2-vbi";
         Log.debug("[DirectoryInitialization] User Dir: " + userPath);
         NativeLibrary.SetUserDirectory(userPath);
         return true;


### PR DESCRIPTION
This sets /mmjr2-vbi in the root of the device as a default user directory. The data of the older MMJR2 build would be preserved in case the user would want to revert to the older build.