### PR TITLE
Remove VBI Skip Hack description from Quick Menu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/QuickSettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/QuickSettingsFragment.java
@@ -173,8 +173,8 @@ public class QuickSettingsFragment extends Fragment implements SettingsFragmentV
             R.string.efb_copy_method, 0));
     sl.add(new CheckBoxSetting(context,BooleanSetting.GFX_HACK_DEFER_EFB_COPIES,
             R.string.defer_efb_copies, 0));
-    sl.add(new CheckBoxSetting(context, BooleanSetting.GFX_HACK_VI_SKIP, R.string.vi_skip,
-            R.string.vi_skip_description));
+    sl.add(new CheckBoxSetting(context, BooleanSetting.GFX_HACK_VI_SKIP,
+            R.string.vi_skip, 0));
     //sl.add(new InvertedCheckBoxSetting(context, BooleanSetting.GFX_HACK_BBOX_ENABLE,R.string.disable_bbox, 0));
 
     mSettingsList = sl;


### PR DESCRIPTION
This removes the long description of the VBI Skip hack from the Quick Settings menu.