### PR TITLE
Small UI strings update

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -132,7 +132,7 @@ dependencies {
 
 def getVersion() 
 {
-    return '2.1-18025'
+    return '2.1-18025rev1-dev'
 }
 
 

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -137,7 +137,7 @@
     <string name="system_language">System Language</string>
     <string name="skip_ipl">Skip IPL</string>
     <string name="skip_ipl_description">"Skips BIOS.
-Requires an ipl.bin file of the correct region to be placed in /mmjr-revamp/GC/REGION/ if unchecked.
+Requires an ipl.bin file of the correct region to be placed in /mmjr2-vbi/GC/REGION/ if unchecked.
 Without the correct bios file, the app may crash due to a bug that I can not fix atm"</string>
     <string name="slot_a_device">GameCube Slot A Device</string>
     <string name="slot_b_device">GameCube Slot B Device</string>
@@ -342,7 +342,7 @@ Without the correct bios file, the app may crash due to a bug that I can not fix
     <string name="disable_bbox_description">Disables bounding box emulation. This may improve GPU performance significantly, but some games will break. If unsure, leave this checked.</string>
     <string name="vertex_rounding">Vertex Rounding</string>
     <string name="vertex_rounding_description">Rounds 2D vertices to whole pixels and rounds the viewport size to a whole number. Fixes graphical problems in some games at higher internal resolutions. This setting has no effect when native internal resolution is used. If unsure, leave this unchecked.</string>
-    <string name="vi_skip">VI Skip</string>
+    <string name="vi_skip">VBI Skip</string>
     <string name="vi_skip_description">Skips VI interrupts when lag is detected, allowing for smooth audio playback when emulation speed is not 100%. Can cause freezes and compatibility issues.</string>
     <string name="texture_cache_to_state">Save Texture Cache to State</string>
     <string name="texture_cache_to_state_description">Includes the contents of the embedded frame buffer (EFB) and upscaled EFB copies in save states. Fixes missing and/or non-upscaled textures/objects when loading states at the cost of additional save/load time.</string>


### PR DESCRIPTION
Updates the UI strings to reflect the custom user directory of this fork and also renames VI Skip to VBI Skip to match Dolphin Official.