### PR TITLE
Integrate "Follow-up on a four-year-old Android NDK workaround" by Minty-Meeo

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -6,7 +6,7 @@ keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
     compileSdkVersion 33
-    ndkVersion "25.0.8775105"
+    ndkVersion "25.1.8937393"
 
     viewBinding.enabled = true
 

--- a/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
+++ b/Source/Core/VideoBackends/Vulkan/VKVertexManager.cpp
@@ -3,6 +3,8 @@
 
 #include "VideoBackends/Vulkan/VKVertexManager.h"
 
+#include <algorithm>
+
 #include "Common/Align.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
@@ -87,11 +89,9 @@ bool VertexManager::Initialize()
 
   // Prefer an 8MB buffer if possible, but use less if the device doesn't support this.
   // This buffer is potentially going to be addressed as R8s in the future, so we assume
-  // that one element is one byte. This doesn't use min() because of a NDK compiler bug..
-  const u32 texel_buffer_size =
-      TEXEL_STREAM_BUFFER_SIZE > g_vulkan_context->GetDeviceLimits().maxTexelBufferElements ?
-          g_vulkan_context->GetDeviceLimits().maxTexelBufferElements :
-          TEXEL_STREAM_BUFFER_SIZE;
+   // that one element is one byte.
+  const u32 texel_buffer_size = std::min(
+      TEXEL_STREAM_BUFFER_SIZE, g_vulkan_context->GetDeviceLimits().maxTexelBufferElements);
   m_texel_stream_buffer =
       StreamBuffer::Create(VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, texel_buffer_size);
   if (!m_texel_stream_buffer)


### PR DESCRIPTION
https://github.com/dolphin-emu/dolphin/pull/11366
Also upgraded NDK to 25.1.8937393.