### PR TITLE
Integrate "VideoCommon/PixelEngine: Refactor to class, move to Core::System" by AdmiralCurtiss

### DIFF
--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -50,7 +50,7 @@ void MemoryManager::InitMMIO(bool is_wii)
 
   auto& system = Core::System::GetInstance();
   system.GetCommandProcessor().RegisterMMIO(system, m_mmio_mapping.get(), 0x0C000000);
-  PixelEngine::RegisterMMIO(m_mmio_mapping.get(), 0x0C001000);
+  system.GetPixelEngine().RegisterMMIO(m_mmio_mapping.get(), 0x0C001000);
   VideoInterface::RegisterMMIO(m_mmio_mapping.get(), 0x0C002000);
   ProcessorInterface::RegisterMMIO(m_mmio_mapping.get(), 0x0C003000);
   MemoryInterface::RegisterMMIO(m_mmio_mapping.get(), 0x0C004000);

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -20,6 +20,7 @@
 #include "Core/HW/VideoInterface.h"
 #include "VideoCommon/CommandProcessor.h"
 #include "VideoCommon/Fifo.h"
+#include "VideoCommon/PixelEngine.h"
 
 namespace Core
 {
@@ -39,6 +40,7 @@ struct System::Impl
   Fifo::FifoManager m_fifo;
   Memory::MemoryManager m_memory;
   MemoryInterface::MemoryInterfaceState m_memory_interface_state;
+  PixelEngine::PixelEngineManager m_pixel_engine;
   SerialInterface::SerialInterfaceState m_serial_interface_state;
   Sram m_sram;
   VideoInterface::VideoInterfaceState m_video_interface_state;
@@ -135,6 +137,11 @@ Memory::MemoryManager& System::GetMemory() const
 MemoryInterface::MemoryInterfaceState& System::GetMemoryInterfaceState() const
 {
   return m_impl->m_memory_interface_state;
+}
+
+PixelEngine::PixelEngineManager& System::GetPixelEngine() const
+{
+  return m_impl->m_pixel_engine;
 }
 
 SerialInterface::SerialInterfaceState& System::GetSerialInterfaceState() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -48,6 +48,10 @@ namespace MemoryInterface
 {
 class MemoryInterfaceState;
 };
+namespace PixelEngine
+{
+class PixelEngineManager;
+};
 namespace SerialInterface
 {
 class SerialInterfaceState;
@@ -101,6 +105,7 @@ public:
   Fifo::FifoManager& GetFifo() const;
   Memory::MemoryManager& GetMemory() const;
   MemoryInterface::MemoryInterfaceState& GetMemoryInterfaceState() const;
+  PixelEngine::PixelEngineManager& GetPixelEngine() const;
   SerialInterface::SerialInterfaceState& GetSerialInterfaceState() const;
   Sram& GetSRAM() const;
   VideoInterface::VideoInterfaceState& GetVideoInterfaceState() const;

--- a/Source/Core/VideoBackends/Software/SWRenderer.cpp
+++ b/Source/Core/VideoBackends/Software/SWRenderer.cpp
@@ -9,6 +9,7 @@
 #include "Common/GL/GLContext.h"
 
 #include "Core/HW/Memmap.h"
+#include "Core/System.h"
 
 #include "VideoBackends/Software/EfbCopy.h"
 #include "VideoBackends/Software/EfbInterface.h"
@@ -136,7 +137,8 @@ u32 SWRenderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 InputData)
     value = (color >> 8) | (color & 0xff) << 24;
 
     // check what to do with the alpha channel (GX_PokeAlphaRead)
-    PixelEngine::AlphaReadMode alpha_read_mode = PixelEngine::GetAlphaReadMode();
+    PixelEngine::AlphaReadMode alpha_read_mode =
+        Core::System::GetInstance().GetPixelEngine().GetAlphaReadMode();
 
     if (alpha_read_mode == PixelEngine::AlphaReadMode::ReadNone)
     {

--- a/Source/Core/VideoCommon/BPStructs.cpp
+++ b/Source/Core/VideoCommon/BPStructs.cpp
@@ -54,7 +54,7 @@ void BPInit()
   bpmem.bpMask = 0xFFFFFF;
 }
 
-static void BPWritten(const BPCmd& bp)
+static void BPWritten(const BPCmd& bp, int cycles_into_future)
 {
   /*
   ----------------------------------------------------------------------------------------------------------------
@@ -186,7 +186,7 @@ static void BPWritten(const BPCmd& bp)
       g_framebuffer_manager->RefreshPeekCache();
       auto& system = Core::System::GetInstance();
       if (!system.GetFifo().UseDeterministicGPUThread())
-        PixelEngine::SetFinish();  // may generate interrupt
+        system.GetPixelEngine().SetFinish(system, cycles_into_future);  // may generate interrupt
       DEBUG_LOG_FMT(VIDEO, "GXSetDrawDone SetPEFinish (value: {:#04X})", bp.newvalue & 0xFFFF);
       return;
     }
@@ -204,7 +204,10 @@ static void BPWritten(const BPCmd& bp)
     g_framebuffer_manager->RefreshPeekCache();
     auto& system = Core::System::GetInstance();
     if (!system.GetFifo().UseDeterministicGPUThread())
-      PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), false);
+    {
+      system.GetPixelEngine().SetToken(system, static_cast<u16>(bp.newvalue & 0xFFFF), false,
+                                       cycles_into_future);
+    }
     DEBUG_LOG_FMT(VIDEO, "SetPEToken {:#06X}", bp.newvalue & 0xFFFF);
     return;
   }
@@ -216,7 +219,10 @@ static void BPWritten(const BPCmd& bp)
     g_framebuffer_manager->RefreshPeekCache();
     auto& system = Core::System::GetInstance();
     if (!system.GetFifo().UseDeterministicGPUThread())
-      PixelEngine::SetToken(static_cast<u16>(bp.newvalue & 0xFFFF), true);
+    {
+      system.GetPixelEngine().SetToken(system, static_cast<u16>(bp.newvalue & 0xFFFF), true,
+                                       cycles_into_future);
+    }
     DEBUG_LOG_FMT(VIDEO, "SetPEToken + INT {:#06X}", bp.newvalue & 0xFFFF);
     return;
   }
@@ -753,24 +759,26 @@ void LoadBPReg(u8 reg, u32 value, int cycles_into_future)
   if (reg != BPMEM_BP_MASK)
     bpmem.bpMask = 0xFFFFFF;
 
-  BPWritten(bp);
+  BPWritten(bp, cycles_into_future);
 }
 
 void LoadBPRegPreprocess(u8 reg, u32 value, int cycles_into_future)
 {
+  auto& system = Core::System::GetInstance();
+  
   // masking via BPMEM_BP_MASK could hypothetically be a problem
   u32 newval = value & 0xffffff;
   switch (reg)
   {
   case BPMEM_SETDRAWDONE:
     if ((newval & 0xff) == 0x02)
-      PixelEngine::SetFinish();
+      system.GetPixelEngine().SetFinish(system, cycles_into_future);
     break;
   case BPMEM_PE_TOKEN_ID:
-    PixelEngine::SetToken(newval & 0xffff, false);
+    system.GetPixelEngine().SetToken(system, newval & 0xffff, false, cycles_into_future);
     break;
   case BPMEM_PE_TOKEN_INT_ID:  // Pixel Engine Interrupt Token ID
-    PixelEngine::SetToken(newval & 0xffff, true);
+    system.GetPixelEngine().SetToken(system, newval & 0xffff, true, cycles_into_future);
     break;
   }
 }

--- a/Source/Core/VideoCommon/PixelEngine.cpp
+++ b/Source/Core/VideoCommon/PixelEngine.cpp
@@ -9,6 +9,7 @@
 #include "Common/ChunkFile.h"
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
+
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -24,188 +25,54 @@
 
 namespace PixelEngine
 {
-// Note: These enums are (assumed to be) identical to the one in BPMemory, but the base type is set
-// to u16 instead of u32 for BitField
-enum class CompareMode : u16
-{
-  Never = 0,
-  Less = 1,
-  Equal = 2,
-  LEqual = 3,
-  Greater = 4,
-  NEqual = 5,
-  GEqual = 6,
-  Always = 7
-};
-
-union UPEZConfReg
-{
-  u16 hex;
-  BitField<0, 1, bool, u16> z_comparator_enable;
-  BitField<1, 3, CompareMode, u16> function;
-  BitField<4, 1, bool, u16> z_update_enable;
-};
-
-enum class SrcBlendFactor : u16
-{
-  Zero = 0,
-  One = 1,
-  DstClr = 2,
-  InvDstClr = 3,
-  SrcAlpha = 4,
-  InvSrcAlpha = 5,
-  DstAlpha = 6,
-  InvDstAlpha = 7
-};
-
-enum class DstBlendFactor : u16
-{
-  Zero = 0,
-  One = 1,
-  SrcClr = 2,
-  InvSrcClr = 3,
-  SrcAlpha = 4,
-  InvSrcAlpha = 5,
-  DstAlpha = 6,
-  InvDstAlpha = 7
-};
-
-enum class LogicOp : u16
-{
-  Clear = 0,
-  And = 1,
-  AndReverse = 2,
-  Copy = 3,
-  AndInverted = 4,
-  NoOp = 5,
-  Xor = 6,
-  Or = 7,
-  Nor = 8,
-  Equiv = 9,
-  Invert = 10,
-  OrReverse = 11,
-  CopyInverted = 12,
-  OrInverted = 13,
-  Nand = 14,
-  Set = 15
-};
-
-union UPEAlphaConfReg
-{
-  u16 hex;
-  BitField<0, 1, bool, u16> blend;  // Set for GX_BM_BLEND or GX_BM_SUBTRACT
-  BitField<1, 1, bool, u16> logic;  // Set for GX_BM_LOGIC
-  BitField<2, 1, bool, u16> dither;
-  BitField<3, 1, bool, u16> color_update_enable;
-  BitField<4, 1, bool, u16> alpha_update_enable;
-  BitField<5, 3, DstBlendFactor, u16> dst_factor;
-  BitField<8, 3, SrcBlendFactor, u16> src_factor;
-  BitField<11, 1, bool, u16> subtract;  // Set for GX_BM_SUBTRACT
-  BitField<12, 4, LogicOp, u16> logic_op;
-};
-
-union UPEDstAlphaConfReg
-{
-  u16 hex;
-  BitField<0, 8, u8, u16> alpha;
-  BitField<8, 1, bool, u16> enable;
-};
-
-union UPEAlphaModeConfReg
-{
-  u16 hex;
-  BitField<0, 8, u8, u16> threshold;
-  // Yagcd and libogc use 8 bits for this, but the enum only needs 3
-  BitField<8, 3, CompareMode, u16> compare_mode;
-};
-
-union UPEAlphaReadReg
-{
-  u16 hex;
-  BitField<0, 2, AlphaReadMode, u16> read_mode;
-};
-
-// fifo Control Register
-union UPECtrlReg
-{
-  u16 hex;
-  BitField<0, 1, bool, u16> pe_token_enable;
-  BitField<1, 1, bool, u16> pe_finish_enable;
-  BitField<2, 1, bool, u16> pe_token;   // Write only
-  BitField<3, 1, bool, u16> pe_finish;  // Write only
-};
-
-// STATE_TO_SAVE
-static UPEZConfReg m_ZConf;
-static UPEAlphaConfReg m_AlphaConf;
-static UPEDstAlphaConfReg m_DstAlphaConf;
-static UPEAlphaModeConfReg m_AlphaModeConf;
-static UPEAlphaReadReg m_AlphaRead;
-static UPECtrlReg m_Control;
-
-static std::mutex s_token_finish_mutex;
-static u16 s_token;
-static u16 s_token_pending;
-static bool s_token_interrupt_pending;
-static bool s_finish_interrupt_pending;
-static bool s_event_raised;
-
-static bool s_signal_token_interrupt;
-static bool s_signal_finish_interrupt;
-
-static CoreTiming::EventType* et_SetTokenFinishOnMainThread;
-
 enum
 {
   INT_CAUSE_PE_TOKEN = 0x200,   // GP Token
   INT_CAUSE_PE_FINISH = 0x400,  // GP Finished
 };
 
-void DoState(PointerWrap& p)
+void PixelEngineManager::DoState(PointerWrap& p)
 {
-  p.Do(m_ZConf);
-  p.Do(m_AlphaConf);
-  p.Do(m_DstAlphaConf);
-  p.Do(m_AlphaModeConf);
-  p.Do(m_AlphaRead);
-  p.Do(m_Control);
+  p.Do(m_z_conf);
+  p.Do(m_alpha_conf);
+  p.Do(m_dst_alpha_conf);
+  p.Do(m_alpha_mode_conf);
+  p.Do(m_alpha_read);
+  p.Do(m_control);
 
-  p.Do(s_token);
-  p.Do(s_token_pending);
-  p.Do(s_token_interrupt_pending);
-  p.Do(s_finish_interrupt_pending);
-  p.Do(s_event_raised);
+  p.Do(m_token);
+  p.Do(m_token_pending);
+  p.Do(m_token_interrupt_pending);
+  p.Do(m_finish_interrupt_pending);
+  p.Do(m_event_raised);
 
-  p.Do(s_signal_token_interrupt);
-  p.Do(s_signal_finish_interrupt);
+  p.Do(m_signal_token_interrupt);
+  p.Do(m_signal_finish_interrupt);
 }
 
-static void UpdateInterrupts();
-static void SetTokenFinish_OnMainThread(Core::System& system, u64 userdata, s64 cyclesLate);
-
-void Init()
+void PixelEngineManager::Init(Core::System& system)
 {
-  m_Control.hex = 0;
-  m_ZConf.hex = 0;
-  m_AlphaConf.hex = 0;
-  m_DstAlphaConf.hex = 0;
-  m_AlphaModeConf.hex = 0;
-  m_AlphaRead.hex = 0;
+  m_control.hex = 0;
+  m_z_conf.hex = 0;
+  m_alpha_conf.hex = 0;
+  m_dst_alpha_conf.hex = 0;
+  m_alpha_mode_conf.hex = 0;
+  m_alpha_read.hex = 0;
 
-  s_token = 0;
-  s_token_pending = 0;
-  s_token_interrupt_pending = false;
-  s_finish_interrupt_pending = false;
-  s_event_raised = false;
+  m_token = 0;
+  m_token_pending = 0;
+  m_token_interrupt_pending = false;
+  m_finish_interrupt_pending = false;
+  m_event_raised = false;
 
-  s_signal_token_interrupt = false;
-  s_signal_finish_interrupt = false;
+  m_signal_token_interrupt = false;
+  m_signal_finish_interrupt = false;
 
-  et_SetTokenFinishOnMainThread = Core::System::GetInstance().GetCoreTiming().RegisterEvent(
-      "SetTokenFinish", SetTokenFinish_OnMainThread);
+m_event_type_set_token_finish =
+      system.GetCoreTiming().RegisterEvent("SetTokenFinish", SetTokenFinish_OnMainThread_Static);
 }
 
-void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
+void PixelEngineManager::RegisterMMIO(MMIO::Mapping* mmio, u32 base)
 {
   // Directly mapped registers.
   struct
@@ -213,11 +80,11 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
     u32 addr;
     u16* ptr;
   } directly_mapped_vars[] = {
-      {PE_ZCONF, &m_ZConf.hex},
-      {PE_ALPHACONF, &m_AlphaConf.hex},
-      {PE_DSTALPHACONF, &m_DstAlphaConf.hex},
-      {PE_ALPHAMODE, &m_AlphaModeConf.hex},
-      {PE_ALPHAREAD, &m_AlphaRead.hex},
+      {PE_ZCONF, &m_z_conf.hex},
+      {PE_ALPHACONF, &m_alpha_conf.hex},
+      {PE_DSTALPHACONF, &m_dst_alpha_conf.hex},
+      {PE_ALPHAMODE, &m_alpha_mode_conf.hex},
+      {PE_ALPHAREAD, &m_alpha_read.hex},
   };
   for (auto& mapped_var : directly_mapped_vars)
   {
@@ -252,27 +119,29 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 
   // Control register
-  mmio->Register(base | PE_CTRL_REGISTER, MMIO::DirectRead<u16>(&m_Control.hex),
-                 MMIO::ComplexWrite<u16>([](Core::System&, u32, u16 val) {
+  mmio->Register(base | PE_CTRL_REGISTER, MMIO::DirectRead<u16>(&m_control.hex),
+                 MMIO::ComplexWrite<u16>([](Core::System& system, u32, u16 val) {
+                   auto& pe = system.GetPixelEngine();
+                   
                    UPECtrlReg tmpCtrl{.hex = val};
 
                    if (tmpCtrl.pe_token)
-                     s_signal_token_interrupt = false;
+                     pe.m_signal_token_interrupt = false;
 
                    if (tmpCtrl.pe_finish)
-                     s_signal_finish_interrupt = false;
+                     pe.m_signal_finish_interrupt = false;
 
-                   m_Control.pe_token_enable = tmpCtrl.pe_token_enable.Value();
-                   m_Control.pe_finish_enable = tmpCtrl.pe_finish_enable.Value();
-                   m_Control.pe_token = false;   // this flag is write only
-                   m_Control.pe_finish = false;  // this flag is write only
+                   pe.m_control.pe_token_enable = tmpCtrl.pe_token_enable.Value();
+                   pe.m_control.pe_finish_enable = tmpCtrl.pe_finish_enable.Value();
+                   pe.m_control.pe_token = false;   // this flag is write only
+                   pe.m_control.pe_finish = false;  // this flag is write only
 
                    DEBUG_LOG_FMT(PIXELENGINE, "(w16) CTRL_REGISTER: {:#06x}", val);
-                   UpdateInterrupts();
+                   pe.UpdateInterrupts();
                  }));
 
   // Token register, readonly.
-  mmio->Register(base | PE_TOKEN_REG, MMIO::DirectRead<u16>(&s_token), MMIO::InvalidWrite<u16>());
+  mmio->Register(base | PE_TOKEN_REG, MMIO::DirectRead<u16>(&m_token), MMIO::InvalidWrite<u16>());
 
   // BBOX registers, readonly and need to update a flag.
   for (int i = 0; i < 4; ++i)
@@ -285,35 +154,42 @@ void RegisterMMIO(MMIO::Mapping* mmio, u32 base)
   }
 }
 
-static void UpdateInterrupts()
+void PixelEngineManager::UpdateInterrupts()
 {
   // check if there is a token-interrupt
   ProcessorInterface::SetInterrupt(INT_CAUSE_PE_TOKEN,
-                                   s_signal_token_interrupt && m_Control.pe_token_enable);
+                                   m_signal_token_interrupt && m_control.pe_token_enable);
 
   // check if there is a finish-interrupt
   ProcessorInterface::SetInterrupt(INT_CAUSE_PE_FINISH,
-                                   s_signal_finish_interrupt && m_Control.pe_finish_enable);
+                                   m_signal_finish_interrupt && m_control.pe_finish_enable);
 }
 
-static void SetTokenFinish_OnMainThread(Core::System& system, u64 userdata, s64 cyclesLate)
+void PixelEngineManager::SetTokenFinish_OnMainThread_Static(Core::System& system, u64 userdata,
+                                                            s64 cycles_late)
 {
-  std::unique_lock<std::mutex> lk(s_token_finish_mutex);
-  s_event_raised = false;
+  system.GetPixelEngine().SetTokenFinish_OnMainThread(system, userdata, cycles_late);
+}
 
-  s_token = s_token_pending;
+void PixelEngineManager::SetTokenFinish_OnMainThread(Core::System& system, u64 userdata,
+                                                     s64 cycles_late)
+{
+  std::unique_lock<std::mutex> lk(m_token_finish_mutex);
+  m_event_raised = false;
 
-  if (s_token_interrupt_pending)
+  m_token = m_token_pending;
+
+  if (m_token_interrupt_pending)
   {
-    s_token_interrupt_pending = false;
-    s_signal_token_interrupt = true;
+    m_token_interrupt_pending = false;
+    m_signal_token_interrupt = true;
     UpdateInterrupts();
   }
 
-  if (s_finish_interrupt_pending)
+  if (m_finish_interrupt_pending)
   {
-    s_finish_interrupt_pending = false;
-    s_signal_finish_interrupt = true;
+    m_finish_interrupt_pending = false;
+    m_signal_finish_interrupt = true;
     UpdateInterrupts();
     lk.unlock();
     Core::FrameUpdateOnCPUThread();
@@ -321,53 +197,54 @@ static void SetTokenFinish_OnMainThread(Core::System& system, u64 userdata, s64 
 }
 
 // Raise the event handler above on the CPU thread.
-// s_token_finish_mutex must be locked.
+// m_token_finish_mutex must be locked.
 // THIS IS EXECUTED FROM VIDEO THREAD
-static void RaiseEvent()
+void PixelEngineManager::RaiseEvent(Core::System& system, int cycles_into_future)
 {
-  if (s_event_raised)
+  if (m_event_raised)
     return;
 
-  s_event_raised = true;
+  m_event_raised = true;
 
   CoreTiming::FromThread from = CoreTiming::FromThread::NON_CPU;
-  auto& system = Core::System::GetInstance();
-  if (!system.IsDualCoreMode() || system.GetFifo().UseDeterministicGPUThread())
+  s64 cycles = 0;  // we don't care about timings for dual core mode.
+ if (!system.IsDualCoreMode() || system.GetFifo().UseDeterministicGPUThread())
+  {
     from = CoreTiming::FromThread::CPU;
-  Core::System::GetInstance().GetCoreTiming().ScheduleEvent(0, et_SetTokenFinishOnMainThread,
-                                                            0, from);
+    
+    // Hack: Dolphin's single-core gpu timings are way too fast. Enforce a minimum delay to give
+    //       games time to setup any interrupt state
+    cycles = std::max(500, cycles_into_future);
+  }
+  system.GetCoreTiming().ScheduleEvent(cycles, m_event_type_set_token_finish, 0, from);
 }
 
 // SetToken
 // THIS IS EXECUTED FROM VIDEO THREAD
-void SetToken(const u16 token, const bool interrupt)
+void PixelEngineManager::SetToken(Core::System& system, const u16 token, const bool interrupt,
+                                  int cycles_into_future)
 {
   DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Backend raises INT_CAUSE_PE_TOKEN (btw, token: {:04x})", token);
 
-  std::lock_guard<std::mutex> lk(s_token_finish_mutex);
+  std::lock_guard<std::mutex> lk(m_token_finish_mutex);
 
-  s_token_pending = token;
-  s_token_interrupt_pending |= interrupt;
+  m_token_pending = token;
+  m_token_interrupt_pending |= interrupt;
 
-  RaiseEvent();
+   RaiseEvent(system, cycles_into_future);
 }
 
 // SetFinish
 // THIS IS EXECUTED FROM VIDEO THREAD (BPStructs.cpp) when a new frame has been drawn
-void SetFinish()
+void PixelEngineManager::SetFinish(Core::System& system, int cycles_into_future)
 {
   DEBUG_LOG_FMT(PIXELENGINE, "VIDEO Set Finish");
 
-  std::lock_guard<std::mutex> lk(s_token_finish_mutex);
+  std::lock_guard<std::mutex> lk(m_token_finish_mutex);
 
-  s_finish_interrupt_pending |= true;
+  m_finish_interrupt_pending |= true;
 
-  RaiseEvent();
-}
-
-AlphaReadMode GetAlphaReadMode()
-{
-  return m_AlphaRead.read_mode;
+  RaiseEvent(system, cycles_into_future);
 }
 
 }  // namespace PixelEngine

--- a/Source/Core/VideoCommon/PixelEngine.h
+++ b/Source/Core/VideoCommon/PixelEngine.h
@@ -3,9 +3,21 @@
 
 #pragma once
 
+#include <mutex>
+
+#include "Common/BitField.h"
 #include "Common/CommonTypes.h"
 
 class PointerWrap;
+
+namespace Core
+{
+class System;
+}
+namespace CoreTiming
+{
+struct EventType;
+}
 
 namespace MMIO
 {
@@ -54,14 +66,156 @@ enum class AlphaReadMode : u16
   ReadNone = 2,  // Always read the real alpha value
 };
 
-void Init();
-void DoState(PointerWrap& p);
+// Note: These enums are (assumed to be) identical to the one in BPMemory, but the base type is set
+// to u16 instead of u32 for BitField
+enum class CompareMode : u16
+{
+  Never = 0,
+  Less = 1,
+  Equal = 2,
+  LEqual = 3,
+  Greater = 4,
+  NEqual = 5,
+  GEqual = 6,
+  Always = 7
+};
 
-void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
+union UPEZConfReg
+{
+  u16 hex = 0;
+  BitField<0, 1, bool, u16> z_comparator_enable;
+  BitField<1, 3, CompareMode, u16> function;
+  BitField<4, 1, bool, u16> z_update_enable;
+};
 
-// gfx backend support
-void SetToken(const u16 token, const bool interrupt);
-void SetFinish();
-AlphaReadMode GetAlphaReadMode();
+enum class SrcBlendFactor : u16
+{
+  Zero = 0,
+  One = 1,
+  DstClr = 2,
+  InvDstClr = 3,
+  SrcAlpha = 4,
+  InvSrcAlpha = 5,
+  DstAlpha = 6,
+  InvDstAlpha = 7
+};
 
+enum class DstBlendFactor : u16
+{
+  Zero = 0,
+  One = 1,
+  SrcClr = 2,
+  InvSrcClr = 3,
+  SrcAlpha = 4,
+  InvSrcAlpha = 5,
+  DstAlpha = 6,
+  InvDstAlpha = 7
+};
+
+enum class LogicOp : u16
+{
+  Clear = 0,
+  And = 1,
+  AndReverse = 2,
+  Copy = 3,
+  AndInverted = 4,
+  NoOp = 5,
+  Xor = 6,
+  Or = 7,
+  Nor = 8,
+  Equiv = 9,
+  Invert = 10,
+  OrReverse = 11,
+  CopyInverted = 12,
+  OrInverted = 13,
+  Nand = 14,
+  Set = 15
+};
+
+union UPEAlphaConfReg
+{
+  u16 hex = 0;
+  BitField<0, 1, bool, u16> blend;  // Set for GX_BM_BLEND or GX_BM_SUBTRACT
+  BitField<1, 1, bool, u16> logic;  // Set for GX_BM_LOGIC
+  BitField<2, 1, bool, u16> dither;
+  BitField<3, 1, bool, u16> color_update_enable;
+  BitField<4, 1, bool, u16> alpha_update_enable;
+  BitField<5, 3, DstBlendFactor, u16> dst_factor;
+  BitField<8, 3, SrcBlendFactor, u16> src_factor;
+  BitField<11, 1, bool, u16> subtract;  // Set for GX_BM_SUBTRACT
+  BitField<12, 4, LogicOp, u16> logic_op;
+};
+
+union UPEDstAlphaConfReg
+{
+  u16 hex = 0;
+  BitField<0, 8, u8, u16> alpha;
+  BitField<8, 1, bool, u16> enable;
+};
+
+union UPEAlphaModeConfReg
+{
+  u16 hex = 0;
+  BitField<0, 8, u8, u16> threshold;
+  // Yagcd and libogc use 8 bits for this, but the enum only needs 3
+  BitField<8, 3, CompareMode, u16> compare_mode;
+};
+
+union UPEAlphaReadReg
+{
+  u16 hex = 0;
+  BitField<0, 2, AlphaReadMode, u16> read_mode;
+};
+
+// fifo Control Register
+union UPECtrlReg
+{
+  u16 hex = 0;
+  BitField<0, 1, bool, u16> pe_token_enable;
+  BitField<1, 1, bool, u16> pe_finish_enable;
+  BitField<2, 1, bool, u16> pe_token;   // Write only
+  BitField<3, 1, bool, u16> pe_finish;  // Write only
+};
+
+class PixelEngineManager
+{
+public:
+  void Init(Core::System& system);
+  void DoState(PointerWrap& p);
+
+  void RegisterMMIO(MMIO::Mapping* mmio, u32 base);
+
+  // gfx backend support
+  void SetToken(Core::System& system, const u16 token, const bool interrupt, int cycle_delay);
+  void SetFinish(Core::System& system, int cycle_delay);
+  AlphaReadMode GetAlphaReadMode() const { return m_alpha_read.read_mode; }
+
+private:
+  void RaiseEvent(Core::System& system, int cycles_into_future);
+  void UpdateInterrupts();
+  void SetTokenFinish_OnMainThread(Core::System& system, u64 userdata, s64 cycles_late);
+
+  static void SetTokenFinish_OnMainThread_Static(Core::System& system, u64 userdata,
+                                                 s64 cycles_late);
+
+  // STATE_TO_SAVE
+  UPEZConfReg m_z_conf;
+  UPEAlphaConfReg m_alpha_conf;
+  UPEDstAlphaConfReg m_dst_alpha_conf;
+  UPEAlphaModeConfReg m_alpha_mode_conf;
+  UPEAlphaReadReg m_alpha_read;
+  UPECtrlReg m_control;
+
+  std::mutex m_token_finish_mutex;
+  u16 m_token = 0;
+  u16 m_token_pending = 0;
+  bool m_token_interrupt_pending = false;
+  bool m_finish_interrupt_pending = false;
+  bool m_event_raised = false;
+
+  bool m_signal_token_interrupt = false;
+  bool m_signal_finish_interrupt = false;
+
+  CoreTiming::EventType* m_event_type_set_token_finish = nullptr;
+};
 }  // namespace PixelEngine

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -291,7 +291,8 @@ u32 Renderer::AccessEFB(EFBAccessType type, u32 x, u32 y, u32 poke_data)
     }
 
     // check what to do with the alpha channel (GX_PokeAlphaRead)
-    PixelEngine::AlphaReadMode alpha_read_mode = PixelEngine::GetAlphaReadMode();
+    PixelEngine::AlphaReadMode alpha_read_mode =
+        Core::System::GetInstance().GetPixelEngine().GetAlphaReadMode();
 
     if (alpha_read_mode == PixelEngine::AlphaReadMode::ReadNone)
     {

--- a/Source/Core/VideoCommon/VideoBackendBase.cpp
+++ b/Source/Core/VideoCommon/VideoBackendBase.cpp
@@ -325,7 +325,7 @@ void VideoBackendBase::InitializeShared()
   auto& command_processor = system.GetCommandProcessor();
   command_processor.Init(system);
   system.GetFifo().Init(system);
-  PixelEngine::Init();
+  system.GetPixelEngine().Init(system);
   BPInit();
   VertexLoaderManager::Init();
   VertexShaderManager::Init();

--- a/Source/Core/VideoCommon/VideoState.cpp
+++ b/Source/Core/VideoCommon/VideoState.cpp
@@ -68,7 +68,7 @@ void VideoCommon_DoState(PointerWrap& p)
   command_processor.DoState(p);
   p.DoMarker("CommandProcessor");
 
-  PixelEngine::DoState(p);
+  system.GetPixelEngine().DoState(p);
   p.DoMarker("PixelEngine");
 
   // the old way of replaying current bpmem as writes to push side effects to pixel shader manager


### PR DESCRIPTION
I already noticed it in https://github.com/Medard22/Dolphin-MMJR2-VBI/pull/6. MMJR2 never properly adopted "Delay single-core GPU interrupts" by phire from 12/2021. Parts of its code were already all over the place when the MMJR2 source code was synced with the official Dolphin repository. This time I made sure it is working properly. Preliminary testing in single-core and dual-core modes hasn´t shown any noticeable performance regression. I searched for possible issues on Github and Dolphin forums and found none. I think it´s safe to keep.