### PR TITLE
Small build fixes

### DIFF
--- a/Externals/curl/curl.vcxproj
+++ b/Externals/curl/curl.vcxproj
@@ -357,9 +357,6 @@
     <ClInclude Include="lib\wildcard.h" />
     <ClInclude Include="lib\x509asn1.h" />
   </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="lib\libcurl.rc" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Source/Core/DolphinLib.props
+++ b/Source/Core/DolphinLib.props
@@ -213,9 +213,6 @@
     <ClInclude Include="Core\DSP\Interpreter\DSPIntTables.h" />
     <ClInclude Include="Core\DSP\Interpreter\DSPIntUtil.h" />
     <ClInclude Include="Core\DSP\Jit\DSPEmitterBase.h" />
-    <ClInclude Include="Core\DSP\Jit\x64\DSPEmitter.h" />
-    <ClInclude Include="Core\DSP\Jit\x64\DSPJitRegCache.h" />
-    <ClInclude Include="Core\DSP\Jit\x64\DSPJitTables.h" />
     <ClInclude Include="Core\DSP\LabelMap.h" />
     <ClInclude Include="Core\DSPEmulator.h" />
     <ClInclude Include="Core\FifoPlayer\FifoDataFile.h" />
@@ -833,17 +830,6 @@
     <ClCompile Include="Core\DSP\Interpreter\DSPIntMultiplier.cpp" />
     <ClCompile Include="Core\DSP\Interpreter\DSPIntTables.cpp" />
     <ClCompile Include="Core\DSP\Jit\DSPEmitterBase.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPEmitter.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitArithmetic.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitBranch.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitCCUtil.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitExtOps.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitLoadStore.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMisc.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMultiplier.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitRegCache.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitTables.cpp" />
-    <ClCompile Include="Core\DSP\Jit\x64\DSPJitUtil.cpp" />
     <ClCompile Include="Core\DSP\LabelMap.cpp" />
     <ClCompile Include="Core\DSPEmulator.cpp" />
     <ClCompile Include="Core\FifoPlayer\FifoDataFile.cpp" />

--- a/Source/Core/DolphinLib.x64.props
+++ b/Source/Core/DolphinLib.x64.props
@@ -4,6 +4,9 @@
     <ClInclude Include="Common\x64ABI.h" />
     <ClInclude Include="Common\x64Emitter.h" />
     <ClInclude Include="Common\x64Reg.h" />
+    <ClInclude Include="Core\DSP\Jit\x64\DSPEmitter.h" />
+    <ClInclude Include="Core\DSP\Jit\x64\DSPJitRegCache.h" />
+    <ClInclude Include="Core\DSP\Jit\x64\DSPJitTables.h" />
     <ClInclude Include="Core\PowerPC\Jit64\Jit.h" />
     <ClInclude Include="Core\PowerPC\Jit64\JitAsm.h" />
     <ClInclude Include="Core\PowerPC\Jit64\RegCache\CachedReg.h" />
@@ -27,6 +30,17 @@
     <ClCompile Include="Common\x64CPUDetect.cpp" />
     <ClCompile Include="Common\x64Emitter.cpp" />
     <ClCompile Include="Common\x64FPURoundMode.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPEmitter.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitArithmetic.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitBranch.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitCCUtil.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitExtOps.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitLoadStore.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMisc.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitMultiplier.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitRegCache.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitTables.cpp" />
+    <ClCompile Include="Core\DSP\Jit\x64\DSPJitUtil.cpp" />
     <ClCompile Include="Core\PowerPC\Jit64\Jit_Branch.cpp" />
     <ClCompile Include="Core\PowerPC\Jit64\Jit_FloatingPoint.cpp" />
     <ClCompile Include="Core\PowerPC\Jit64\Jit_Integer.cpp" />

--- a/Tools/lint.sh
+++ b/Tools/lint.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 # use Windows' git when working under path mounted from host on wsl2
 # inspired by https://markentier.tech/posts/2020/10/faster-git-under-wsl2/#solution
 GIT=git
-if [ "$(stat --file-system --format=%T `pwd -P`)" == "v9fs" ]; then
-  GIT=git.exe
+if [ "$(uname -s)" == "Linux" ]; then
+  if [ "$(stat --file-system --format=%T `pwd -P`)" == "v9fs" ]; then
+    GIT=git.exe
+  fi
 fi
 
 if ! [ -x "$(command -v $GIT)" ]; then


### PR DESCRIPTION
Contains:

Move x64 DSP JIT into DolphinLib.x64.props by Pokechu22
https://github.com/dolphin-emu/dolphin/pull/11414

Externals: Exclude libcurl.rc from the build by Pokechu22
https://github.com/dolphin-emu/dolphin/pull/11394

lint: Don't check for WSL2 host path on non-Linux OSes by OatmealDome
https://github.com/dolphin-emu/dolphin/pull/10986
