### PR TITLE
Make uninitialized XFB black instead of magenta

### DIFF
--- a/Source/Core/VideoCommon/TextureCacheBase.cpp
+++ b/Source/Core/VideoCommon/TextureCacheBase.cpp
@@ -2522,10 +2522,10 @@ void TextureCacheBase::UninitializeXFBMemory(u8* dst, u32 stride, u32 bytes_per_
   // was still a desire to differentiate between the old and the new approach
   // which is why we still set uninitialized xfb memory to fuchsia
   // (Y=1,U=254,V=254) instead of dark green (Y=0,U=0,V=0) in YUV
-  // like is done in the EFB path.
+  // like is done in the EFB path. MMJR2-VBI sets it to black (Y=0,U=128,V=128)
 
 #if defined(_M_X86) || defined(_M_X86_64)
-  __m128i sixteenBytes = _mm_set1_epi16((s16)(u16)0xFE01);
+  __m128i sixteenBytes = _mm_set1_epi16((s16)(u16)0x8080);
 #endif
 
   for (u32 i = 0; i < num_blocks_y; i++)
@@ -2544,11 +2544,11 @@ void TextureCacheBase::UninitializeXFBMemory(u8* dst, u32 stride, u32 bytes_per_
     {
       if (offset & 1)
       {
-        rowdst[offset] = 254;
+        rowdst[offset] = 128; // U and V components
       }
       else
       {
-        rowdst[offset] = 1;
+        rowdst[offset] = 0; //Y component
       }
     }
     dst += stride;


### PR DESCRIPTION
This was bugging me a lot and it took me quite some time to find the code that was responsible for this. I was looking for pink color, feature article mentioned magenta and the code eventually calls it fuchsia :D 

Back in 2017 when iwubcode made Hybrid XFB they set the color of the uninitialized XFB to magenta. It was mostly for the debugging purposes as this bright key color sticks out like a sore thumb in the game rendering, pointing to issues with XFB. 
Accuratelly emulating XFB is however very demanding process that copies frames from VRAM to host system memory, thus degrading performance. Even more so on Android devices. There is a hack called "Store XFB copies to Texture only". This one disables copying frames from VRAM and instead initializes the main memory with arbitrary color. This speeds up emulation considerably, but also causes magenta colored artifacts.

This PR changes the magenta color to black. It will not fix rendering glitches, but it will make them less noticeable. There is a downside to this - games that rely on proper XFB emulation will have rendering issues with this speedhack on, that will be hard to debug. That´s why Dolphin official could never make change like that. On the other hand a lot of games can benefit from this speedhack making the artifacts almost unnoticeable - like transitions in Beyond Good and Evil or Eternal Darkness. 

The bottomline - if you have rendering issues don´t forget to turn off speedhacks - especially "Store XFB copies to Texture only", "Store EFB copies to Texture only" and "Skip EFB Access from CPU". You can always run the games in Dolphin Official with the same configuration. Magenta colored artifacts means that game requires accurate XFB emulation.

More information about XFB in this Dolphin´s feature article:
https://dolphin-emu.org/blog/2017/11/19/hybridxfb/
