### PR TITLE
Add "Store XFB Copies to Texture Only" hack to Quick Settings menu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/QuickSettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/QuickSettingsFragment.java
@@ -173,6 +173,8 @@ public class QuickSettingsFragment extends Fragment implements SettingsFragmentV
             R.string.efb_copy_method, 0));
     sl.add(new CheckBoxSetting(context,BooleanSetting.GFX_HACK_DEFER_EFB_COPIES,
             R.string.defer_efb_copies, 0));
+    sl.add(new CheckBoxSetting(context, BooleanSetting.GFX_HACK_SKIP_XFB_COPY_TO_RAM,
+            R.string.xfb_copy_method, 0));
     sl.add(new CheckBoxSetting(context, BooleanSetting.GFX_HACK_VI_SKIP,
             R.string.vi_skip, 0));
     //sl.add(new InvertedCheckBoxSetting(context, BooleanSetting.GFX_HACK_BBOX_ENABLE,R.string.disable_bbox, 0));


### PR DESCRIPTION
Pretty much what the title says. This particular hack may break rendering in many games when on. Now it´s easier to reach.