### PR TITLE
Hide Autoupdater from Interface settings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -331,8 +331,8 @@ public final class SettingsFragmentPresenter
             R.string.osd_messages_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.MAIN_USE_GAME_COVERS,
             R.string.download_game_covers, 0));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.UPDATER_CHECK_AT_STARTUP, R.string.updater_check_startup,
-            R.string.updater_check_startup_description));
+    //sl.add(new CheckBoxSetting(mContext, BooleanSetting.UPDATER_CHECK_AT_STARTUP, R.string.updater_check_startup,
+    //        R.string.updater_check_startup_description));
   }
 
   private void addAudioSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -185,7 +185,7 @@ Without the correct bios file, the app may crash due to a bug that I can not fix
     <string name="analytics_new_id">Generate a New Statistics Identity</string>
     <string name="analytics_new_id_confirmation">Are you sure you want to generate a new statistics identity?</string>
     <string name="gametdb_thanks">Special thanks to Weihuoya + Dolphin Team for getting this emulator to where it is today.</string>
-    <string name="dev_thanks">Dolphin |MMJR2| made by bankaimaster999 and sspacelynx.</string>
+    <string name="dev_thanks">Dolphin |MMJR2| made by bankaimaster999, sspacelynx and Lumince.</string>
 
     <!-- SerialPort1 Subsetting Fragment -->
     <string name="serialport1_submenu">Serial Port 1</string>


### PR DESCRIPTION
Enabling this doesn´t do anything, but since it doesn´t work anyway, let´s just hide it from the UI for now. 