### PR TITLE
Core: Remove obsolete MMJR2 FPS code

### DIFF
--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -86,6 +86,7 @@
 #include "VideoCommon/Fifo.h"
 #include "VideoCommon/HiresTextures.h"
 #include "VideoCommon/OnScreenDisplay.h"
+#include "VideoCommon/PerformanceMetrics.h"
 #include "VideoCommon/RenderBase.h"
 #include "VideoCommon/VideoBackendBase.h"
 
@@ -98,8 +99,6 @@ namespace Core
 static bool s_wants_determinism;
 
 // Declarations and definitions
-static PerformanceStatistics perf_stats;
-
 static bool s_is_stopping = false;
 static bool s_hardware_initialized = false;
 static bool s_is_started = false;
@@ -241,9 +240,6 @@ bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
 
   // Issue any API calls which must occur on the main thread for the graphics backend.
   WindowSystemInfo prepared_wsi(wsi);
-
-  static PerformanceStatistics perf_stats;
-
   g_video_backend->PrepareWindow(prepared_wsi);
 
   // Start the emu thread
@@ -870,12 +866,6 @@ void Callback_NewField()
     }
   }
 }
-
-const PerformanceStatistics& GetPerformanceStatistics()
-{
-    return perf_stats;
-}
-
 
 void UpdateTitle()
 {

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -115,15 +115,6 @@ bool WantsDeterminism();
 void SetState(State state);
 State GetState();
 
-struct PerformanceStatistics
-{
-    float FPS;
-    float VPS;
-    float Speed;
-};
-
-const PerformanceStatistics& GetPerformanceStatistics();
-
 void SaveScreenShot();
 void SaveScreenShot(std::string_view name);
 

--- a/Source/Core/VideoCommon/RenderBase.cpp
+++ b/Source/Core/VideoCommon/RenderBase.cpp
@@ -633,6 +633,7 @@ void Renderer::DrawDebugText()
       else if (Config::Get(Config::MAIN_SHOW_FRAME_COUNT))
       {
         ImGui::Text("Frame: %" PRIu64, Movie::GetCurrentFrame());
+        ImGui::Text("Input: %" PRIu64, Movie::GetCurrentInputCount());
       }
       if (Config::Get(Config::MAIN_SHOW_LAG))
         ImGui::Text("Lag: %" PRIu64 "\n", Movie::GetCurrentLagCount());


### PR DESCRIPTION
This code was made obsolete by changes to FPS/VPS counters and CoreTiming changes. While working on it I fixed a missing include and added a missing line of code from following PR.

RenderBase: Show input count on m_ShowFrameCount by malleoz
https://github.com/dolphin-emu/dolphin/pull/10136