### PR TITLE
Remove "Skip Approximate Logic Op" Hack

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -234,8 +234,6 @@ public enum BooleanSetting implements AbstractBooleanSetting
           "DisableCopyFilter", false),
   GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
           "ArbitraryMipmapDetection", true),
-  GFX_ENHANCE_SKIP_APPROXIMATE_LOGIC_OP(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
-          "SkipApproximateLogicOp", false),
 
   GFX_STEREO_SWAP_EYES(Settings.FILE_GFX, Settings.SECTION_STEREOSCOPY, "StereoSwapEyes", false),
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -760,8 +760,6 @@ public final class SettingsFragmentPresenter
             R.string.disable_copy_filter, R.string.disable_copy_filter_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION,
             R.string.arbitrary_mipmap_detection, R.string.arbitrary_mipmap_detection_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_ENHANCE_SKIP_APPROXIMATE_LOGIC_OP,
-            R.string.skip_approximate_logic_op, R.string.skip_approximate_logic_op_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_WIDESCREEN_HACK,
             R.string.wide_screen_hack, R.string.wide_screen_hack_description));
     sl.add(new InvertedCheckBoxSetting(mContext, BooleanSetting.GFX_HACK_FAST_TEXTURE_SAMPLING,

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -299,8 +299,6 @@ Without the correct bios file, the app may crash due to a bug that I can not fix
     <string name="disable_copy_filter_description">Disables the blending of adjacent rows when copying the EFB. This is known in some games as \"deflickering\" or \"smoothing\". Disabling the filter is usually safe, and may result in a sharper image.</string>
     <string name="arbitrary_mipmap_detection">Arbitrary Mipmap Detection</string>
     <string name="arbitrary_mipmap_detection_description">Enables detection of arbitrary mipmaps, which some games use for special distance-based effects.\nMay have false positives that result in blurry textures at increased internal resolution, such as in games that use very low resolution mipmaps. Disabling this can also reduce stutter in games that frequently load new textures.\n\nIf unsure, leave this checked.</string>
-    <string name="skip_approximate_logic_op">Skip Approximate Logic Op</string>
-    <string name="skip_approximate_logic_op_description">Disable this could fix graphical errors in some games, but may cause graphical errors in others!</string>
     <string name="stereoscopy_submenu">Stereoscopy</string>
     <string name="stereoscopy_submenu_description">Stereoscopy allows you to get a better feeling of depth if you have the necessary hardware.\nHeavily decreases emulation speed and sometimes causes issues</string>
     <string name="wide_screen_hack">Widescreen Hack</string>

--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -122,8 +122,6 @@ const Info<bool> GFX_ENHANCE_DISABLE_COPY_FILTER{{System::GFX, "Enhancements", "
                                                  true};
 const Info<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetection"}, true};
-const Info<bool> GFX_ENHANCE_SKIP_APPROXIMATE_LOGIC_OP{
-    {System::GFX, "Enhancements", "SkipApproximateLogicOp"}, false};
 const Info<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD{
     {System::GFX, "Enhancements", "ArbitraryMipmapDetectionThreshold"}, 14.0f};
 

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -103,7 +103,6 @@ extern const Info<std::string> GFX_ENHANCE_POST_SHADER;
 extern const Info<bool> GFX_ENHANCE_FORCE_TRUE_COLOR;
 extern const Info<bool> GFX_ENHANCE_DISABLE_COPY_FILTER;
 extern const Info<bool> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION;
-extern const Info<bool> GFX_ENHANCE_SKIP_APPROXIMATE_LOGIC_OP;
 extern const Info<float> GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD;
 
 // Graphics.Stereoscopy

--- a/Source/Core/VideoCommon/RenderState.cpp
+++ b/Source/Core/VideoCommon/RenderState.cpp
@@ -7,7 +7,6 @@
 #include <array>
 
 #include "VideoCommon/TextureConfig.h"
-#include "VideoConfig.h"
 
 void RasterizationState::Generate(const BPMemory& bp, PrimitiveType primitive_type)
 {
@@ -184,11 +183,6 @@ void BlendingState::Generate(const BPMemory& bp)
 
 void BlendingState::ApproximateLogicOpWithBlending()
 {
-  if (g_ActiveConfig.bSkipApproximateLogicOp)
-  {
-    return;
-  }
-
   struct LogicOpApproximation
   {
     bool blendEnable;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -122,7 +122,6 @@ void VideoConfig::Refresh()
   bForceTrueColor = Config::Get(Config::GFX_ENHANCE_FORCE_TRUE_COLOR);
   bDisableCopyFilter = Config::Get(Config::GFX_ENHANCE_DISABLE_COPY_FILTER);
   bArbitraryMipmapDetection = Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION);
-  bSkipApproximateLogicOp = Config::Get(Config::GFX_ENHANCE_SKIP_APPROXIMATE_LOGIC_OP);
   fArbitraryMipmapDetectionThreshold =
       Config::Get(Config::GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION_THRESHOLD);
 

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -86,7 +86,6 @@ struct VideoConfig final
   bool bForceTrueColor = false;
   bool bDisableCopyFilter = false;
   bool bArbitraryMipmapDetection = false;
-  bool bSkipApproximateLogicOp = false;
   float fArbitraryMipmapDetectionThreshold = 0;
 
   // Information


### PR DESCRIPTION
Dolphin uses a logic op approximation fallback on GPU´s that don´t support them properly (mostly mobile GPU´s). "Skip Approximate Logic Op" is a hack, that bypasses this fallback. Depending on GPU used, this may have fixed rendering issues on the handful of games that actually uses logic ops or break them completely. I think we don´t need this hack anymore. It is incompatible with improvements to logic op approximations, games render just fine without it, and the information about what it actually does is so obscure that most people using MMJR2 have no idea what it actually does.