### PR TITLE
Android: Fixed Touch IR Pointer Mode Selection

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/EmulationActivity.java
@@ -1042,19 +1042,14 @@ public final class EmulationActivity extends AppCompatActivity
 
   private void setIRMode()
   {
-    final SharedPreferences.Editor editor = mPreferences.edit();
     AlertDialog.Builder builder = new AlertDialog.Builder(this);
     builder.setTitle(R.string.emulation_ir_mode);
     builder.setSingleChoiceItems(R.array.irModeEntries,
-      mPreferences.getInt("irMode", InputOverlayPointer.MODE_FOLLOW),
-      (dialog, indexSelected) ->
-      {
-        editor.putInt("irMode", indexSelected);
-      });
+            IntSetting.MAIN_IR_MODE.getInt(mSettings),
+            (dialog, indexSelected) ->
+                    IntSetting.MAIN_IR_MODE.setInt(mSettings, indexSelected));
     builder.setPositiveButton(R.string.ok, (dialogInterface, i) ->
-      {
-        editor.apply();
-      });
+            mEmulationFragment.refreshOverlayPointer(mSettings));
 
     builder.show();
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlay.java
@@ -911,6 +911,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
   {
     if (overlayPointer != null)
     {
+      overlayPointer.setMode(IntSetting.MAIN_IR_MODE.getInt(settings));
       overlayPointer.setRecenter(BooleanSetting.MAIN_IR_ALWAYS_RECENTER.getBoolean(settings));
     }
   }

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/overlay/InputOverlayPointer.java
@@ -53,7 +53,7 @@ public class InputOverlayPointer
   {
     doubleTapButton = button;
     mMode = mode;
-	mRecenter = recenter;
+    mRecenter = recenter;
 
     mGameCenterX = (surfacePosition.left + surfacePosition.right) / 2.0f;
     mGameCenterY = (surfacePosition.top + surfacePosition.bottom) / 2.0f;
@@ -127,7 +127,7 @@ public class InputOverlayPointer
   private void touchPress()
   {
     if (mMode != MODE_DISABLED)
-     {
+    {
       if (doubleTap)
       {
         NativeLibrary.onGamePadEvent(NativeLibrary.TouchScreenDevice,
@@ -141,8 +141,8 @@ public class InputOverlayPointer
         doubleTap = true;
         new Handler().postDelayed(() -> doubleTap = false, 300);
       }
-     }
-   }
+    }
+  }
 
   private void updateOldAxes()
   {
@@ -174,9 +174,6 @@ public class InputOverlayPointer
 
   public void setRecenter(boolean recenter)
   {
-    if(recenter != mRecenter)
-    {
-      mRecenter = recenter;
-    }
+    mRecenter = recenter;
   }
 }


### PR DESCRIPTION
There was a long standing bug in MMJR2 - the Touch IR Pointer mode "drag" never worked. There was an old code in the function that creates Touch IR Pointer Mode Alert Dialog. Most likely from the time when this feature was ported over from MMJR. Now it works as it should :)