### PR TITLE
Android: Hide MMJR2 Updater from the context menu

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/MainPresenter.java
@@ -138,10 +138,6 @@ public final class MainPresenter
         new AfterDirectoryInitializationRunner().runWithLifecycle(activity,
                 () -> mView.launchOpenFileActivity(REQUEST_NAND_BIN_FILE));
         return true;
-
-      case R.id.updater_dialog:
-        mView.openUpdaterDialog();
-        return true;
     }
 
     return false;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/ui/main/TvMainActivity.java
@@ -382,10 +382,6 @@ public final class TvMainActivity extends FragmentActivity
             R.drawable.ic_add_tv,
             R.string.add_directory_title));
 
-    rowItems.add(new TvSettingsItem(R.id.updater_dialog,
-      R.drawable.ic_cheat_load,
-      R.string.grid_menu_open_updater));
-
     rowItems.add(new TvSettingsItem(R.id.menu_refresh,
             R.drawable.ic_refresh,
             R.string.grid_menu_refresh));

--- a/Source/Android/app/src/main/res/menu/menu_game_grid.xml
+++ b/Source/Android/app/src/main/res/menu/menu_game_grid.xml
@@ -60,9 +60,4 @@
         android:title="@string/grid_menu_import_nand_backup"
         app:showAsAction="never"/>
 
-    <item
-        android:id="@+id/updater_dialog"
-        android:title="@string/grid_menu_open_updater"
-        app:showAsAction="never"/>
-
 </menu>


### PR DESCRIPTION
MMJR2 Updater is not working ever since I forked the repository. It requires a specific setup on github, in build.gradle and in the app itself. The updater expects a specific version number, it will crash otherwise. I really don´t know how to make it work properly, so for now I hid the updater from the context menu.