### PR TITLE
"Externals/FreeSurround: Fix pointer created through new[] being freed via delete" by Pokechu22

### DIFF
--- a/Externals/FreeSurround/source/FreeSurroundDecoder.cpp
+++ b/Externals/FreeSurround/source/FreeSurroundDecoder.cpp
@@ -31,10 +31,8 @@ DPL2FSDecoder::DPL2FSDecoder() {
 }
 
 DPL2FSDecoder::~DPL2FSDecoder() {
-#pragma warning(suppress : 4150)
-  delete forward;
-#pragma warning(suppress : 4150)
-  delete inverse;
+kiss_fftr_free(forward);
+kiss_fftr_free(inverse);
 }
 
 void DPL2FSDecoder::Init(channel_setup chsetup, unsigned int blsize,

--- a/Externals/FreeSurround/source/KissFFTR.cpp
+++ b/Externals/FreeSurround/source/KissFFTR.cpp
@@ -65,7 +65,7 @@ kiss_fftr_cfg kiss_fftr_alloc(int nfft, int inverse_fft, void *mem,
               sizeof(kiss_fft_cpx) * (nfft * 3 / 2);
 
   if (lenmem == NULL) {
-    st = (kiss_fftr_cfg) new char[memneeded];
+    st = (kiss_fftr_cfg)malloc(memneeded);
   } else {
     if (*lenmem >= memneeded)
       st = (kiss_fftr_cfg)mem;


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/11573