### PR TITLE
Revert InputCommon: Fix ControlGroup::SaveConfig with DefaultValue::Disabled

### DIFF
--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -57,7 +57,7 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
 
   // enabled
   if (default_value != DefaultValue::AlwaysEnabled)
-    sec->Get(group + "Enabled", &enabled, default_value != DefaultValue::Disabled);
+    sec->Get(group + "Enabled", &enabled, default_value == DefaultValue::Enabled);
 
   for (auto& setting : numeric_settings)
     setting->LoadFromIni(*sec, group);
@@ -109,7 +109,7 @@ void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
   const std::string group(base + name + "/");
 
   // enabled
-  sec->Set(group + "Enabled", enabled, default_value != DefaultValue::Disabled);
+  sec->Set(group + "Enabled", enabled, true);
 
   for (auto& setting : numeric_settings)
     setting->SaveToIni(*sec, group);


### PR DESCRIPTION
This "Revert InputCommon: Fix ControlGroup::SaveConfig with DefaultValue::Disabled" is most likely not needed unless I would try to port Android Input Overhaul. Somehow this seems to cause a small performance regression, so I am reverting it for now. 