### PR TITLE
"Jit: Don't use a second stack" by JosJuice

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -201,26 +201,18 @@ std::unique_ptr<GBAHostInterface> Host_CreateGBAHost(std::weak_ptr<HW::GBA::Core
 
 static bool MsgAlert(const char* caption, const char* text, bool yes_no, Common::MsgType style)
 {
-  // If a panic alert happens very early in the execution of a game, we can crash here with
-  // the error "JNI NewString called with pending exception java.lang.StackOverflowError".
-  // As a workaround, let's put the call on a new thread with a brand new stack.
+  JNIEnv* env = IDCache::GetEnvForThread();
 
-  jboolean result;
+  jstring j_caption = ToJString(env, caption);
+  jstring j_text = ToJString(env, text);
 
-  std::thread([&] {
-    JNIEnv* env = IDCache::GetEnvForThread();
-
-    jstring j_caption = ToJString(env, caption);
-    jstring j_text = ToJString(env, text);
-
-    // Execute the Java method.
-    result = env->CallStaticBooleanMethod(
-        IDCache::GetNativeLibraryClass(), IDCache::GetDisplayAlertMsg(), j_caption, j_text, yes_no,
-        style == Common::MsgType::Warning, s_need_nonblocking_alert_msg);
-
-    env->DeleteLocalRef(j_caption);
-    env->DeleteLocalRef(j_text);
-  }).join();
+  // Execute the Java method.
+  jboolean result = env->CallStaticBooleanMethod(
+      IDCache::GetNativeLibraryClass(), IDCache::GetDisplayAlertMsg(), j_caption, j_text, yes_no,
+      style == Common::MsgType::Warning, s_need_nonblocking_alert_msg);
+  
+  env->DeleteLocalRef(j_caption);
+  env->DeleteLocalRef(j_text);
 
   return result != JNI_FALSE;
 }

--- a/Source/Core/Common/ChunkFile.h
+++ b/Source/Core/Common/ChunkFile.h
@@ -105,7 +105,7 @@ public:
     case Mode::Read:
       for (x.clear(); count != 0; --count)
       {
-        V value;
+        V value = {};
         Do(value);
         x.insert(value);
       }

--- a/Source/Core/Common/Logging/ConsoleListener.h
+++ b/Source/Core/Common/Logging/ConsoleListener.h
@@ -14,5 +14,7 @@ public:
   void Log(Common::Log::LogLevel level, const char* text) override;
 
 private:
-  [[maybe_unused]] bool m_use_color = false;
+#if !defined _WIN32 && !defined ANDROID
+  bool m_use_color = false;
+#endif
 };

--- a/Source/Core/Common/Thread.h
+++ b/Source/Core/Common/Thread.h
@@ -5,6 +5,10 @@
 
 #include <thread>
 
+#ifndef _WIN32
+#include <tuple>
+#endif
+
 // Don't include Common.h here as it will break LogManager
 #include "Common/CommonTypes.h"
 
@@ -34,5 +38,10 @@ inline void YieldCPU()
 }
 
 void SetCurrentThreadName(const char* name);
+
+#ifndef _WIN32
+// Returns the lowest address of the stack and the size of the stack
+std::tuple<void*, size_t> GetCurrentThreadStack();
+#endif
 
 }  // namespace Common

--- a/Source/Core/Core/DSP/DSPDisassembler.cpp
+++ b/Source/Core/Core/DSP/DSPDisassembler.cpp
@@ -194,7 +194,7 @@ bool DSPDisassembler::DisassembleOpcode(const u16* binbuf, size_t binbuf_size, u
   // Size 2 - the op has a large immediate.
   if (opc->size == 2)
   {
-    if (wrapped_pc + 1 >= binbuf_size)
+    if (wrapped_pc + 1u >= binbuf_size)
     {
       if (settings_.show_hex)
         dest += fmt::format("{:04x} ???? ", op1);

--- a/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
+++ b/Source/Core/Core/IOS/USB/Bluetooth/BTReal.cpp
@@ -90,12 +90,13 @@ std::optional<IPCReply> BluetoothRealDevice::Open(const OpenRequest& request)
   const int ret = m_context.GetDeviceList([this](libusb_device* device) {
     libusb_device_descriptor device_descriptor;
     libusb_get_device_descriptor(device, &device_descriptor);
-    auto [ret, config_descriptor] = LibusbUtils::MakeConfigDescriptor(device);
-    if (ret != LIBUSB_SUCCESS || !config_descriptor)
+    auto [make_config_descriptor_ret, config_descriptor] =
+        LibusbUtils::MakeConfigDescriptor(device);
+    if (make_config_descriptor_ret != LIBUSB_SUCCESS || !config_descriptor)
     {
       ERROR_LOG_FMT(IOS_WIIMOTE, "Failed to get config descriptor for device {:04x}:{:04x}: {}",
                     device_descriptor.idVendor, device_descriptor.idProduct,
-                    LibusbUtils::ErrorWrap(ret));
+                    LibusbUtils::ErrorWrap(make_config_descriptor_ret));
       return true;
     }
 

--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -19,7 +19,6 @@
 #include "Common/GekkoDisassembler.h"
 #include "Common/IOFile.h"
 #include "Common/Logging/Log.h"
-#include "Common/MemoryUtil.h"
 #include "Common/PerformanceCounter.h"
 #include "Common/StringUtil.h"
 #include "Common/Swap.h"
@@ -117,108 +116,21 @@ using namespace PowerPC;
     and such, but it's currently limited to integer ops only. This can definitely be made better.
 */
 
-// The BLR optimization is nice, but it means that JITted code can overflow the
-// native stack by repeatedly running BL.  (The chance of this happening in any
-// retail game is close to 0, but correctness is correctness...) Also, the
-// overflow might not happen directly in the JITted code but in a C++ function
-// called from it, so we can't just adjust RSP in the case of a fault.
-// Instead, we have to have extra stack space preallocated under the fault
-// point which allows the code to continue, after wiping the JIT cache so we
-// can reset things at a safe point.  Once this condition trips, the
-// optimization is permanently disabled, under the assumption this will never
-// happen in practice.
-
-// On Unix, we just mark an appropriate region of the stack as PROT_NONE and
-// handle it the same way as fastmem faults.  It's safe to take a fault with a
-// bad RSP, because on Linux we can use sigaltstack and on OS X we're already
-// on a separate thread.
-
-// Windows is... under-documented.
-// It already puts guard pages so it can automatically grow the stack and it
-// doesn't look like there is a way to hook into a guard page fault and implement
-// our own logic.
-// But when windows reaches the last guard page, it raises a "Stack Overflow"
-// exception which we can hook into, however by default it leaves you with less
-// than 4kb of stack. So we use SetThreadStackGuarantee to trigger the Stack
-// Overflow early while we still have 512kb of stack remaining.
-// After resetting the stack to the top, we call _resetstkoflw() to restore
-// the guard page at the 512kb mark.
-
-enum
-{
-  STACK_SIZE = 2 * 1024 * 1024,
-  SAFE_STACK_SIZE = 512 * 1024,
-  GUARD_SIZE = 0x10000,  // two guards - bottom (permanent) and middle (see above)
-  GUARD_OFFSET = STACK_SIZE - SAFE_STACK_SIZE - GUARD_SIZE,
-};
-
 Jit64::Jit64() : QuantizedMemoryRoutines(*this)
 {
 }
 
 Jit64::~Jit64() = default;
 
-void Jit64::AllocStack()
-{
-#ifndef _WIN32
-  m_stack = static_cast<u8*>(Common::AllocateMemoryPages(STACK_SIZE));
-  Common::ReadProtectMemory(m_stack, GUARD_SIZE);
-  Common::ReadProtectMemory(m_stack + GUARD_OFFSET, GUARD_SIZE);
-#else
-  // For windows we just keep using the system stack and reserve a large amount of memory at the end
-  // of the stack.
-  ULONG reserveSize = SAFE_STACK_SIZE;
-  SetThreadStackGuarantee(&reserveSize);
-#endif
-}
-
-void Jit64::FreeStack()
-{
-#ifndef _WIN32
-  if (m_stack)
-  {
-    Common::FreeMemoryPages(m_stack, STACK_SIZE);
-    m_stack = nullptr;
-  }
-#endif
-}
-
-bool Jit64::HandleStackFault()
-{
-  // It's possible the stack fault might have been caused by something other than
-  // the BLR optimization. If the fault was triggered from another thread, or
-  // when BLR optimization isn't enabled then there is nothing we can do about the fault.
-  // Return false so the regular stack overflow handler can trigger (which crashes)
-  if (!m_enable_blr_optimization || !Core::IsCPUThread())
-    return false;
-
-  WARN_LOG_FMT(POWERPC, "BLR cache disabled due to excessive BL in the emulated program.");
-
-  m_enable_blr_optimization = false;
-#ifndef _WIN32
-  // Windows does this automatically.
-  Common::UnWriteProtectMemory(m_stack + GUARD_OFFSET, GUARD_SIZE);
-#endif
-  // We're going to need to clear the whole cache to get rid of the bad
-  // CALLs, but we can't yet.  Fake the downcount so we're forced to the
-  // dispatcher (no block linking), and clear the cache so we're sent to
-  // Jit. In the case of Windows, we will also need to call _resetstkoflw()
-  // to reset the guard page.
-  // Yeah, it's kind of gross.
-  GetBlockCache()->InvalidateICache(0, 0xffffffff, true);
-  Core::System::GetInstance().GetCoreTiming().ForceExceptionCheck(0);
-  m_cleanup_after_stackfault = true;
-
-  return true;
-}
-
 bool Jit64::HandleFault(uintptr_t access_address, SContext* ctx)
 {
-  uintptr_t stack = (uintptr_t)m_stack;
-  uintptr_t diff = access_address - stack;
+  const uintptr_t stack_guard = reinterpret_cast<uintptr_t>(m_stack_guard);
   // In the trap region?
-  if (m_enable_blr_optimization && diff >= GUARD_OFFSET && diff < GUARD_OFFSET + GUARD_SIZE)
+  if (m_enable_blr_optimization && access_address >= stack_guard &&
+      access_address < stack_guard + GUARD_SIZE)
+  {
     return HandleStackFault();
+  }
 
   // This generates some fairly heavy trampolines, but it doesn't really hurt.
   // Only instructions that access I/O will get these, and there won't be that
@@ -365,17 +277,10 @@ void Jit64::Init()
   m_const_pool.Init(AllocChildCodeSpace(constpool_size), constpool_size);
   ResetCodePtr();
 
-  // BLR optimization has the same consequences as block linking, as well as
-  // depending on the fault handler to be safe in the event of excessive BL.
-  m_enable_blr_optimization = jo.enableBlocklink && m_fastmem_enabled && !m_enable_debugging;
-  m_cleanup_after_stackfault = false;
-
-  m_stack = nullptr;
-  if (m_enable_blr_optimization)
-    AllocStack();
+  m_stack_guard = nullptr;
 
   blocks.Init();
-  asm_routines.Init(m_stack ? (m_stack + STACK_SIZE) : nullptr);
+  asm_routines.Init();
 
   // important: do this *after* generating the global asm routines, because we can't use farcode in
   // them.
@@ -415,7 +320,6 @@ void Jit64::ResetFreeMemoryRanges()
 
 void Jit64::Shutdown()
 {
-  FreeStack();
   FreeCodeSpace();
 
   auto& system = Core::System::GetInstance();
@@ -735,14 +639,22 @@ void Jit64::WriteExternalExceptionExit()
 
 void Jit64::Run()
 {
+  ProtectStack();
+
   CompiledCode pExecAddr = (CompiledCode)asm_routines.enter_code;
   pExecAddr();
+
+  UnprotectStack();
 }
 
 void Jit64::SingleStep()
 {
+  ProtectStack();
+
   CompiledCode pExecAddr = (CompiledCode)asm_routines.enter_code;
   pExecAddr();
+
+  UnprotectStack();
 }
 
 void Jit64::Trace()
@@ -779,15 +691,7 @@ void Jit64::Jit(u32 em_address)
 
 void Jit64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
 {
-  if (m_cleanup_after_stackfault)
-  {
-    ClearCache();
-    m_cleanup_after_stackfault = false;
-#ifdef _WIN32
-    // The stack is in an invalid state with no guard page, reset it.
-    _resetstkoflw();
-#endif
-  }
+  CleanUpAfterStackFault();
 
   if (trampolines.IsAlmostFull() || SConfig::GetInstance().bJITNoBlockCache)
   {

--- a/Source/Core/Core/PowerPC/Jit64/Jit.h
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.h
@@ -50,7 +50,6 @@ public:
   void Shutdown() override;
 
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
-  bool HandleStackFault() override;
   bool BackPatch(SContext* ctx);
 
   void EnableOptimization();
@@ -255,9 +254,6 @@ private:
 
   bool HandleFunctionHooking(u32 address);
 
-  void AllocStack();
-  void FreeStack();
-
   void ResetFreeMemoryRanges();
 
   JitBlockCache blocks{*this};
@@ -267,10 +263,6 @@ private:
   FPURegCache fpr{*this};
 
   Jit64AsmRoutineManager asm_routines{*this};
-
-  bool m_enable_blr_optimization = false;
-  bool m_cleanup_after_stackfault = false;
-  u8* m_stack = nullptr;
 
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_near;
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_far;

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -24,10 +24,9 @@ Jit64AsmRoutineManager::Jit64AsmRoutineManager(Jit64& jit) : CommonAsmRoutines(j
 {
 }
 
-void Jit64AsmRoutineManager::Init(u8* stack_top)
+void Jit64AsmRoutineManager::Init()
 {
   m_const_pool.Init(AllocChildCodeSpace(4096), 4096);
-  m_stack_top = stack_top;
   Generate();
   WriteProtect();
 }
@@ -50,17 +49,8 @@ void Jit64AsmRoutineManager::Generate()
   // MOV(64, R(RMEM), Imm64((u64)Memory::physical_base));
   MOV(64, R(RPPCSTATE), Imm64((u64)&PowerPC::ppcState + 0x80));
 
-  if (m_stack_top)
-  {
-    // Pivot the stack to our custom one.
-    MOV(64, R(RSCRATCH), R(RSP));
-    MOV(64, R(RSP), ImmPtr(m_stack_top - 0x20));
-    MOV(64, MDisp(RSP, 0x18), R(RSCRATCH));
-  }
-  else
-  {
-    MOV(64, PPCSTATE(stored_stack_pointer), R(RSP));
-  }
+  MOV(64, PPCSTATE(stored_stack_pointer), R(RSP));
+
   // something that can't pass the BLR test
   MOV(64, MDisp(RSP, 8), Imm32((u32)-1));
 
@@ -105,7 +95,7 @@ void Jit64AsmRoutineManager::Generate()
 
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
-  
+
   // The following is a translation of JitBaseBlockCache::Dispatch into assembly.
   const bool assembly_dispatcher = true;
   if (assembly_dispatcher)
@@ -208,13 +198,10 @@ void Jit64AsmRoutineManager::Generate()
   dispatcher_exit = GetCodePtr();
   if (enable_debugging)
     SetJumpTarget(dbg_exit);
-  
+
+  // Reset the stack pointer, since the BLR optimization may have pushed things onto the stack
+  // without popping them.
   ResetStack(*this);
-  if (m_stack_top)
-  {
-    ADD(64, R(RSP), Imm8(0x18));
-    POP(RSP);
-  }
 
   ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8, 16);
   RET();
@@ -226,10 +213,7 @@ void Jit64AsmRoutineManager::Generate()
 
 void Jit64AsmRoutineManager::ResetStack(X64CodeBlock& emitter)
 {
-  if (m_stack_top)
-    emitter.MOV(64, R(RSP), Imm64((u64)m_stack_top - 0x20));
-  else
-    emitter.MOV(64, R(RSP), PPCSTATE(stored_stack_pointer));
+  emitter.MOV(64, R(RSP), PPCSTATE(stored_stack_pointer));
 }
 
 void Jit64AsmRoutineManager::GenerateCommon()

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.h
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.h
@@ -36,7 +36,7 @@ public:
 
   explicit Jit64AsmRoutineManager(Jit64& jit);
 
-  void Init(u8* stack_top);
+  void Init();
 
   void ResetStack(Gen::X64CodeBlock& emitter);
 
@@ -44,6 +44,5 @@ private:
   void Generate();
   void GenerateCommon();
 
-  u8* m_stack_top = nullptr;
   JitBase& m_jit;
 };

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -38,11 +38,6 @@ constexpr size_t CODE_SIZE = 1024 * 1024 * 32;
 constexpr size_t FARCODE_SIZE = 1024 * 1024 * 64;
 constexpr size_t FARCODE_SIZE_MMU = 1024 * 1024 * 64;
 
-constexpr size_t STACK_SIZE = 2 * 1024 * 1024;
-constexpr size_t SAFE_STACK_SIZE = 512 * 1024;
-constexpr size_t GUARD_SIZE = 64 * 1024;  // two guards - bottom (permanent) and middle (see above)
-constexpr size_t GUARD_OFFSET = STACK_SIZE - SAFE_STACK_SIZE - GUARD_SIZE;
-
 JitArm64::JitArm64() : m_float_emit(this)
 {
 }
@@ -71,10 +66,6 @@ void JitArm64::Init()
   code_block.m_gpa = &js.gpa;
   code_block.m_fpa = &js.fpa;
 
-  m_enable_blr_optimization = jo.enableBlocklink && m_fastmem_enabled && !m_enable_debugging;
-  m_cleanup_after_stackfault = false;
-
-  AllocStack();
   GenerateAsm();
 
   ResetFreeMemoryRanges();
@@ -117,9 +108,8 @@ bool JitArm64::HandleFault(uintptr_t access_address, SContext* ctx)
   bool success = false;
 
   // Handle BLR stack faults, may happen in C++ code.
-  uintptr_t stack = (uintptr_t)m_stack_base;
-  uintptr_t diff = access_address - stack;
-  if (diff >= GUARD_OFFSET && diff < GUARD_OFFSET + GUARD_SIZE)
+  const uintptr_t stack_guard = reinterpret_cast<uintptr_t>(m_stack_guard);
+  if (access_address >= stack_guard && access_address < stack_guard + GUARD_SIZE)
     success = HandleStackFault();
 
   // If the fault is in JIT code space, look for fastmem areas.
@@ -156,23 +146,6 @@ bool JitArm64::HandleFault(uintptr_t access_address, SContext* ctx)
   return success;
 }
 
-bool JitArm64::HandleStackFault()
-{
-  if (!m_enable_blr_optimization)
-    return false;
-
-  ERROR_LOG_FMT(POWERPC, "BLR cache disabled due to excessive BL in the emulated program.");
-  m_enable_blr_optimization = false;
-#ifndef _WIN32
-  Common::UnWriteProtectMemory(m_stack_base + GUARD_OFFSET, GUARD_SIZE);
-#endif
-  GetBlockCache()->InvalidateICache(0, 0xffffffff, true);
-  Core::System::GetInstance().GetCoreTiming().ForceExceptionCheck(0);
-  m_cleanup_after_stackfault = true;
-
-  return true;
-}
-
 void JitArm64::ClearCache()
 {
   m_fault_to_handler.clear();
@@ -205,7 +178,6 @@ void JitArm64::Shutdown()
   memory.ShutdownFastmemArena();
   FreeCodeSpace();
   blocks.Shutdown();
-  FreeStack();
 }
 
 void JitArm64::FallBackToInterpreter(UGeckoInstruction inst)
@@ -335,40 +307,6 @@ void JitArm64::ResetStack()
 
   LDR(IndexType::Unsigned, ARM64Reg::X0, PPC_REG, PPCSTATE_OFF(stored_stack_pointer));
   ADD(ARM64Reg::SP, ARM64Reg::X0, 0);
-}
-
-void JitArm64::AllocStack()
-{
-  if (!m_enable_blr_optimization)
-    return;
-
-#ifndef _WIN32
-  m_stack_base = static_cast<u8*>(Common::AllocateMemoryPages(STACK_SIZE));
-  if (!m_stack_base)
-  {
-    m_enable_blr_optimization = false;
-    return;
-  }
-
-  m_stack_pointer = m_stack_base + STACK_SIZE;
-  Common::ReadProtectMemory(m_stack_base, GUARD_SIZE);
-  Common::ReadProtectMemory(m_stack_base + GUARD_OFFSET, GUARD_SIZE);
-#else
-  // For windows we just keep using the system stack and reserve a large amount of memory at the end
-  // of the stack.
-  ULONG reserveSize = SAFE_STACK_SIZE;
-  SetThreadStackGuarantee(&reserveSize);
-#endif
-}
-
-void JitArm64::FreeStack()
-{
-#ifndef _WIN32
-  if (m_stack_base)
-    Common::FreeMemoryPages(m_stack_base, STACK_SIZE);
-  m_stack_base = nullptr;
-  m_stack_pointer = nullptr;
-#endif
 }
 
 void JitArm64::IntializeSpeculativeConstants()
@@ -696,14 +634,22 @@ void JitArm64::EndTimeProfile(JitBlock* b)
 
 void JitArm64::Run()
 {
+  ProtectStack();
+
   CompiledCode pExecAddr = (CompiledCode)enter_code;
   pExecAddr();
+
+  UnprotectStack();
 }
 
 void JitArm64::SingleStep()
 {
+  ProtectStack();
+
   CompiledCode pExecAddr = (CompiledCode)enter_code;
   pExecAddr();
+
+  UnprotectStack();
 }
 
 void JitArm64::Trace()
@@ -740,15 +686,7 @@ void JitArm64::Jit(u32 em_address)
 
 void JitArm64::Jit(u32 em_address, bool clear_cache_and_retry_on_failure)
 {
-  if (m_cleanup_after_stackfault)
-  {
-    ClearCache();
-    m_cleanup_after_stackfault = false;
-#ifdef _WIN32
-    // The stack is in an invalid state with no guard page, reset it.
-    _resetstkoflw();
-#endif
-  }
+  CleanUpAfterStackFault();
 
   if (SConfig::GetInstance().bJITNoBlockCache)
     ClearCache();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.h
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.h
@@ -32,7 +32,6 @@ public:
   bool IsInCodeSpace(const u8* ptr) const { return IsInSpace(ptr); }
   bool HandleFault(uintptr_t access_address, SContext* ctx) override;
   void DoBacktrace(uintptr_t access_address, SContext* ctx);
-  bool HandleStackFault() override;
   bool HandleFastmemFault(SContext* ctx);
 
   void ClearCache() override;
@@ -288,8 +287,6 @@ protected:
   void DoDownCount();
   void Cleanup();
   void ResetStack();
-  void AllocStack();
-  void FreeStack();
 
   void ResetFreeMemoryRanges();
 
@@ -362,12 +359,6 @@ protected:
   u8* m_near_code = nullptr;
   u8* m_near_code_end = nullptr;
   bool m_near_code_write_failed = false;
-
-  bool m_enable_blr_optimization = false;
-  bool m_cleanup_after_stackfault = false;
-  u8* m_stack_base = nullptr;
-  u8* m_stack_pointer = nullptr;
-  u8* m_saved_stack_pointer = nullptr;
 
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_near;
   HyoutaUtilities::RangeSizeSet<u8*> m_free_ranges_far;

--- a/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/JitAsm.cpp
@@ -45,22 +45,13 @@ void JitArm64::GenerateAsm()
 
   MOVP2R(PPC_REG, &PowerPC::ppcState);
 
-  // Swap the stack pointer, so we have proper guard pages.
+  // Store the stack pointer, so we can reset it if the BLR optimization fails.
   ADD(ARM64Reg::X0, ARM64Reg::SP, 0);
-  STR(IndexType::Unsigned, ARM64Reg::X0, ARM64Reg::X1,
-      MOVPage2R(ARM64Reg::X1, &m_saved_stack_pointer));
-  LDR(IndexType::Unsigned, ARM64Reg::X0, ARM64Reg::X1, MOVPage2R(ARM64Reg::X1, &m_stack_pointer));
-  FixupBranch no_fake_stack = CBZ(ARM64Reg::X0);
-  ADD(ARM64Reg::SP, ARM64Reg::X0, 0);
-  SetJumpTarget(no_fake_stack);
+  STR(IndexType::Unsigned, ARM64Reg::X0, PPC_REG, PPCSTATE_OFF(stored_stack_pointer));
 
   // Push {nullptr; -1} as invalid destination on the stack.
   MOVI2R(ARM64Reg::X0, 0xFFFFFFFF);
   STP(IndexType::Pre, ARM64Reg::ZR, ARM64Reg::X0, ARM64Reg::SP, -16);
-
-  // Store the stack pointer, so we can reset it if the BLR optimization fails.
-  ADD(ARM64Reg::X0, ARM64Reg::SP, 0);
-  STR(IndexType::Unsigned, ARM64Reg::X0, PPC_REG, PPCSTATE_OFF(stored_stack_pointer));
 
   // The PC will be loaded into DISPATCHER_PC after the call to CoreTiming::Advance().
   // Advance() does an exception check so we don't know what PC to use until afterwards.
@@ -97,11 +88,11 @@ void JitArm64::GenerateAsm()
         MOVPage2R(ARM64Reg::X0, CPU::GetStatePtr()));
     debug_exit = CBNZ(ARM64Reg::W0);
   }
-  
+
   dispatcher_no_check = GetCodePtr();
 
   bool assembly_dispatcher = true;
-  
+
   auto& system = Core::System::GetInstance();
   auto& memory = system.GetMemory();
 
@@ -204,9 +195,9 @@ void JitArm64::GenerateAsm()
   if (enable_debugging)
     SetJumpTarget(debug_exit);
 
-  // Reset the stack pointer, as the BLR optimization have touched it.
-  LDR(IndexType::Unsigned, ARM64Reg::X0, ARM64Reg::X1,
-      MOVPage2R(ARM64Reg::X1, &m_saved_stack_pointer));
+  // Reset the stack pointer, since the BLR optimization may have pushed things onto the stack
+  // without popping them.
+  LDR(IndexType::Unsigned, ARM64Reg::X0, PPC_REG, PPCSTATE_OFF(stored_stack_pointer));
   ADD(ARM64Reg::SP, ARM64Reg::X0, 0);
 
   m_float_emit.ABI_PopRegisters(regs_to_save_fpr, ARM64Reg::X30);
@@ -280,8 +271,8 @@ void JitArm64::GenerateFres()
   RET();
 
   SetJumpTarget(small_exponent);
-  FixupBranch zero = B(CCFlags::CC_EQ);
   TST(ARM64Reg::X1, LogicalImm(Common::DOUBLE_EXP | Common::DOUBLE_FRAC, 64));
+  FixupBranch zero = B(CCFlags::CC_EQ);
   MOVI2R(ARM64Reg::X4,
          Common::BitCast<u64>(static_cast<double>(std::numeric_limits<float>::max())));
   ORR(ARM64Reg::X0, ARM64Reg::X3, ARM64Reg::X4);
@@ -311,8 +302,8 @@ void JitArm64::GenerateFrsqrte()
   // inf, even the mantissa matches. But the mantissa does not match for most other inputs, so in
   // the normal case we calculate the mantissa using the table-based algorithm from the interpreter.
 
-  TST(ARM64Reg::X1, LogicalImm(Common::DOUBLE_EXP | Common::DOUBLE_FRAC, 64));
   m_float_emit.FMOV(ARM64Reg::X0, ARM64Reg::D0);
+  TST(ARM64Reg::X1, LogicalImm(Common::DOUBLE_EXP | Common::DOUBLE_FRAC, 64));
   FixupBranch zero = B(CCFlags::CC_EQ);
   AND(ARM64Reg::X2, ARM64Reg::X1, LogicalImm(Common::DOUBLE_EXP, 64));
   MOVI2R(ARM64Reg::X3, Common::DOUBLE_EXP);

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.cpp
@@ -3,14 +3,52 @@
 
 #include "Core/PowerPC/JitCommon/JitBase.h"
 
+#include "Common/Align.h"
 #include "Common/CommonTypes.h"
+#include "Common/MemoryUtil.h"
+#include "Common/Thread.h"
 #include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
+#include "Core/CoreTiming.h"
 #include "Core/HW/CPU.h"
 #include "Core/PowerPC/PPCAnalyst.h"
 #include "Core/PowerPC/PowerPC.h"
 #include "Core/System.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <processthreadsapi.h>
+#else
+#include <unistd.h>
+#endif
+
+// The BLR optimization is nice, but it means that JITted code can overflow the
+// native stack by repeatedly running BL.  (The chance of this happening in any
+// retail game is close to 0, but correctness is correctness...) Also, the
+// overflow might not happen directly in the JITted code but in a C++ function
+// called from it, so we can't just adjust RSP in the case of a fault.
+// Instead, we have to have extra stack space preallocated under the fault
+// point which allows the code to continue, after wiping the JIT cache so we
+// can reset things at a safe point.  Once this condition trips, the
+// optimization is permanently disabled, under the assumption this will never
+// happen in practice.
+
+// On Unix, we just mark an appropriate region of the stack as PROT_NONE and
+// handle it the same way as fastmem faults.  It's safe to take a fault with a
+// bad RSP, because on Linux we can use sigaltstack and on OS X we're already
+// on a separate thread.
+
+// Windows is... under-documented.
+// It already puts guard pages so it can automatically grow the stack and it
+// doesn't look like there is a way to hook into a guard page fault and implement
+// our own logic.
+// But when windows reaches the last guard page, it raises a "Stack Overflow"
+// exception which we can hook into, however by default it leaves you with less
+// than 4kb of stack. So we use SetThreadStackGuarantee to trigger the Stack
+// Overflow early while we still have 256kb of stack remaining.
+// After resetting the stack to the top, we call _resetstkoflw() to restore
+// the guard page at the 256kb mark.
 
 const u8* JitBase::Dispatch(JitBase& jit)
 {
@@ -62,7 +100,7 @@ void JitBase::RefreshConfig()
   if (m_accurate_cpu_cache_enabled)
   {
     m_fastmem_enabled = false;
-     // This hack is unneeded if the data cache is being emulated.
+    // This hack is unneeded if the data cache is being emulated.
     m_low_dcbz_hack = false;
   }
 
@@ -70,6 +108,107 @@ void JitBase::RefreshConfig()
   analyzer.SetBranchFollowingEnabled(Config::Get(Config::MAIN_JIT_FOLLOW_BRANCH));
   analyzer.SetFloatExceptionsEnabled(m_enable_float_exceptions);
   analyzer.SetDivByZeroExceptionsEnabled(m_enable_div_by_zero_exceptions);
+}
+
+void JitBase::InitBLROptimization()
+{
+  m_enable_blr_optimization = jo.enableBlocklink && m_fastmem_enabled && !m_enable_debugging;
+  m_cleanup_after_stackfault = false;
+}
+
+void JitBase::ProtectStack()
+{
+  if (!m_enable_blr_optimization)
+    return;
+
+#ifdef _WIN32
+  ULONG reserveSize = SAFE_STACK_SIZE;
+  SetThreadStackGuarantee(&reserveSize);
+#else
+  auto [stack_addr, stack_size] = Common::GetCurrentThreadStack();
+
+  const uintptr_t stack_base_addr = reinterpret_cast<uintptr_t>(stack_addr);
+  const uintptr_t stack_middle_addr = reinterpret_cast<uintptr_t>(&stack_addr);
+  if (stack_middle_addr < stack_base_addr || stack_middle_addr >= stack_base_addr + stack_size)
+  {
+    PanicAlertFmt("Failed to get correct stack base");
+    m_enable_blr_optimization = false;
+    return;
+  }
+
+  const long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0)
+  {
+    PanicAlertFmt("Failed to get page size");
+    m_enable_blr_optimization = false;
+    return;
+  }
+
+  const uintptr_t stack_guard_addr = Common::AlignUp(stack_base_addr + GUARD_OFFSET, page_size);
+  if (stack_guard_addr >= stack_middle_addr ||
+      stack_middle_addr - stack_guard_addr < GUARD_SIZE + MIN_UNSAFE_STACK_SIZE)
+  {
+    PanicAlertFmt("Stack is too small for BLR optimization (size {:x}, base {:x}, current stack "
+                  "pointer {:x}, alignment {:x})",
+                  stack_size, stack_base_addr, stack_middle_addr, page_size);
+    m_enable_blr_optimization = false;
+    return;
+  }
+
+  m_stack_guard = reinterpret_cast<u8*>(stack_guard_addr);
+  Common::ReadProtectMemory(m_stack_guard, GUARD_SIZE);
+#endif
+}
+
+void JitBase::UnprotectStack()
+{
+#ifndef _WIN32
+  if (m_stack_guard)
+  {
+    Common::UnWriteProtectMemory(m_stack_guard, GUARD_SIZE);
+    m_stack_guard = nullptr;
+  }
+#endif
+}
+
+bool JitBase::HandleStackFault()
+{
+  // It's possible the stack fault might have been caused by something other than
+  // the BLR optimization. If the fault was triggered from another thread, or
+  // when BLR optimization isn't enabled then there is nothing we can do about the fault.
+  // Return false so the regular stack overflow handler can trigger (which crashes)
+  if (!m_enable_blr_optimization || !Core::IsCPUThread())
+    return false;
+
+  WARN_LOG_FMT(POWERPC, "BLR cache disabled due to excessive BL in the emulated program.");
+
+  UnprotectStack();
+  m_enable_blr_optimization = false;
+
+  // We're going to need to clear the whole cache to get rid of the bad
+  // CALLs, but we can't yet.  Fake the downcount so we're forced to the
+  // dispatcher (no block linking), and clear the cache so we're sent to
+  // Jit. In the case of Windows, we will also need to call _resetstkoflw()
+  // to reset the guard page.
+  // Yeah, it's kind of gross.
+  GetBlockCache()->InvalidateICache(0, 0xffffffff, true);
+  Core::System::GetInstance().GetCoreTiming().ForceExceptionCheck(0);
+  m_cleanup_after_stackfault = true;
+
+  return true;
+}
+
+void JitBase::CleanUpAfterStackFault()
+{
+  if (m_cleanup_after_stackfault)
+  {
+    ClearCache();
+    m_cleanup_after_stackfault = false;
+#ifdef _WIN32
+    // The stack is in an invalid state with no guard page, reset it.
+    _resetstkoflw();
+#endif
+  }
 }
 
 bool JitBase::CanMergeNextInstructions(int count) const

--- a/Source/Core/Core/PowerPC/JitCommon/JitBase.h
+++ b/Source/Core/Core/PowerPC/JitCommon/JitBase.h
@@ -54,6 +54,12 @@ protected:
 #endif
   };
 
+  static constexpr size_t SAFE_STACK_SIZE = 256 * 1024;
+  static constexpr size_t MIN_UNSAFE_STACK_SIZE = 192 * 1024;
+  static constexpr size_t MIN_STACK_SIZE = SAFE_STACK_SIZE + MIN_UNSAFE_STACK_SIZE;
+  static constexpr size_t GUARD_SIZE = 64 * 1024;
+  static constexpr size_t GUARD_OFFSET = SAFE_STACK_SIZE - GUARD_SIZE;
+
   struct JitOptions
   {
     bool enableBlocklink;
@@ -94,7 +100,7 @@ protected:
     u8* trampolineExceptionHandler;
 
     bool mustCheckFifo;
-    int fifoBytesSinceCheck;
+    u32 fifoBytesSinceCheck;
 
     PPCAnalyst::BlockStats st;
     PPCAnalyst::BlockRegStats gpa;
@@ -138,7 +144,16 @@ protected:
   bool m_pause_on_panic_enabled = false;
   bool m_accurate_cpu_cache_enabled = false;
 
+  bool m_enable_blr_optimization = false;
+  bool m_cleanup_after_stackfault = false;
+  u8* m_stack_guard = nullptr;
+
   void RefreshConfig();
+
+  void InitBLROptimization();
+  void ProtectStack();
+  void UnprotectStack();
+  void CleanUpAfterStackFault();
 
   bool CanMergeNextInstructions(int count) const;
 
@@ -160,7 +175,7 @@ public:
   virtual const CommonAsmRoutinesBase* GetAsmRoutines() = 0;
 
   virtual bool HandleFault(uintptr_t access_address, SContext* ctx) = 0;
-  virtual bool HandleStackFault() { return false; }
+  bool HandleStackFault();
 
   static constexpr std::size_t code_buffer_size = 32000;
 

--- a/Source/Core/DolphinQt/WiiUpdate.cpp
+++ b/Source/Core/DolphinQt/WiiUpdate.cpp
@@ -75,7 +75,7 @@ static void ShowResult(QWidget* parent, WiiUtils::UpdateResult result)
   default:
     ASSERT(false);
     break;
-	}
+  }
 }
 
 template <typename Callable, typename... Args>

--- a/Source/Core/VideoBackends/Software/Rasterizer.cpp
+++ b/Source/Core/VideoBackends/Software/Rasterizer.cpp
@@ -28,14 +28,14 @@ static constexpr int BLOCK_SIZE = 2;
 struct SlopeContext
 {
   SlopeContext(const OutputVertexData* v0, const OutputVertexData* v1, const OutputVertexData* v2,
-               s32 x0, s32 y0, s32 x_off, s32 y_off)
-      : x0(x0), y0(y0)
+               s32 x0_, s32 y0_, s32 x_off, s32 y_off)
+      : x0(x0_), y0(y0_)
   {
     // adjust a little less than 0.5
     const float adjust = 0.495f;
 
-    xOff = ((float)x0 - (v0->screenPosition.x - x_off)) + adjust;
-    yOff = ((float)y0 - (v0->screenPosition.y - y_off)) + adjust;
+    xOff = ((float)x0_ - (v0->screenPosition.x - x_off)) + adjust;
+    yOff = ((float)y0_ - (v0->screenPosition.y - y_off)) + adjust;
 
     dx10 = v1->screenPosition.x - v0->screenPosition.x;
     dx20 = v2->screenPosition.x - v0->screenPosition.x;
@@ -55,10 +55,10 @@ struct SlopeContext
 struct Slope
 {
   Slope() = default;
-  Slope(float f0, float f1, float f2, const SlopeContext& ctx) : f0(f0)
+  Slope(float f0_, float f1, float f2, const SlopeContext& ctx) : f0(f0_)
   {
-    float delta_20 = f2 - f0;
-    float delta_10 = f1 - f0;
+    float delta_20 = f2 - f0_;
+    float delta_10 = f1 - f0_;
 
     //        x2 - x0    y1 - y0    x1 - x0    y2 - y0
     float a = delta_20 * ctx.dy10 - delta_10 * ctx.dy20;
@@ -366,9 +366,9 @@ static void DrawTriangleFrontFace(const OutputVertexData* v0, const OutputVertex
 
   // scissor
   ASSERT(scissor.rect.left >= 0);
-  ASSERT(scissor.rect.right <= EFB_WIDTH);
+  ASSERT(scissor.rect.right <= static_cast<int>(EFB_WIDTH));
   ASSERT(scissor.rect.top >= 0);
-  ASSERT(scissor.rect.bottom <= EFB_HEIGHT);
+  ASSERT(scissor.rect.bottom <= static_cast<int>(EFB_HEIGHT));
 
   minx = std::max(minx, scissor.rect.left);
   maxx = std::min(maxx, scissor.rect.right);

--- a/Source/Core/VideoCommon/Statistics.cpp
+++ b/Source/Core/VideoCommon/Statistics.cpp
@@ -356,12 +356,12 @@ void Statistics::DisplayScissor()
 
     // Visualization of where things are updated on screen with this specific scissor
     ImGui::TableNextColumn();
-    float scale = ImGui::GetTextLineHeight() / EFB_HEIGHT;
+    float scale_height = ImGui::GetTextLineHeight() / EFB_HEIGHT;
     if (show_raw_scissors)
-      scale += ImGui::GetTextLineHeightWithSpacing() / EFB_HEIGHT;
+      scale_height += ImGui::GetTextLineHeightWithSpacing() / EFB_HEIGHT;
     ImVec2 p2 = ImGui::GetCursorScreenPos();
     // Use a height of 1 since we want this to span two table rows (if possible)
-    ImGui::Dummy(ImVec2(EFB_WIDTH * scale, 1));
+    ImGui::Dummy(ImVec2(EFB_WIDTH * scale_height, 1));
     for (size_t i = 0; i < info.m_result.size(); i++)
     {
       // The last entry in the sorted list of results is the one that is used by hardware backends
@@ -370,11 +370,12 @@ void Statistics::DisplayScissor()
       const ImU32 new_col = (col & ~IM_COL32_A_MASK) | (new_alpha << IM_COL32_A_SHIFT);
 
       const auto& r = info.m_result[i];
-      draw_list->AddRectFilled(ImVec2(p2.x + r.rect.left * scale, p2.y + r.rect.top * scale),
-                               ImVec2(p2.x + r.rect.right * scale, p2.y + r.rect.bottom * scale),
-                               new_col);
+      draw_list->AddRectFilled(
+          ImVec2(p2.x + r.rect.left * scale_height, p2.y + r.rect.top * scale_height),
+          ImVec2(p2.x + r.rect.right * scale_height, p2.y + r.rect.bottom * scale_height), new_col);
     }
-    draw_list->AddRect(p2, ImVec2(p2.x + EFB_WIDTH * scale, p2.y + EFB_HEIGHT * scale), light_grey);
+    draw_list->AddRect(
+        p2, ImVec2(p2.x + EFB_WIDTH * scale_height, p2.y + EFB_HEIGHT * scale_height), light_grey);
     ImGui::SameLine();
     ImGui::Text("%d", int(info.m_result.size()));
 
@@ -448,7 +449,7 @@ void Statistics::DisplayScissor()
           draw_scissor_table_header();
           for (size_t i = 0; i < scissors.size(); i++)
             draw_scissor_table_row(i);
-          for (size_t i = scissors.size(); i < scissor_expected_count; i++)
+          for (size_t i = scissors.size(); i < static_cast<size_t>(scissor_expected_count); i++)
             scissor_table_skip_row(i);
           ImGui::EndTable();
         }
@@ -460,7 +461,7 @@ void Statistics::DisplayScissor()
           draw_viewport_table_header();
           for (size_t i = 0; i < scissors.size(); i++)
             draw_viewport_table_row(i);
-          for (size_t i = scissors.size(); i < scissor_expected_count; i++)
+          for (size_t i = scissors.size(); i < static_cast<size_t>(scissor_expected_count); i++)
             viewport_table_skip_row(i);
           ImGui::EndTable();
         }


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/10908

Also changed order of a two instructions missed from here
+ https://github.com/dolphin-emu/dolphin/pull/11127

And included fixes from here, at least where they were still relevant
+ https://github.com/dolphin-emu/dolphin/pull/10624

**This PR causes a performance drop, because of missing Blr optimization. It will be fixed in the next PR.**