### PR TITLE
Blr optimization fix

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit.cpp
@@ -277,6 +277,8 @@ void Jit64::Init()
   m_const_pool.Init(AllocChildCodeSpace(constpool_size), constpool_size);
   ResetCodePtr();
 
+  InitBLROptimization();
+
   m_stack_guard = nullptr;
 
   blocks.Init();

--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
@@ -66,6 +66,8 @@ void JitArm64::Init()
   code_block.m_gpa = &js.gpa;
   code_block.m_fpa = &js.fpa;
 
+  InitBLROptimization();
+
   GenerateAsm();
 
   ResetFreeMemoryRanges();


### PR DESCRIPTION
+ https://github.com/Medard22/Dolphin-MMJR2-VBI/pull/152 comes with a significant performance hit because of missing Blr optimization. 

We fix it by adding part of the PR mentioned below by krnlyng.
+ https://github.com/dolphin-emu/dolphin/pull/11840