### PR TITLE
Android: Dependency updates

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -13,7 +13,7 @@ android {
         compileSdk 33
     }
 
-    ndkVersion "25.1.8937393"
+    ndkVersion "25.2.9519653"
 
     viewBinding.enabled = true
 
@@ -113,15 +113,15 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.6.0'
-    implementation 'androidx.exifinterface:exifinterface:1.3.5'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel:2.6.0'
     implementation 'androidx.fragment:fragment:1.5.5'
     implementation 'androidx.slidingpanelayout:slidingpanelayout:1.2.0'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.profileinstaller:profileinstaller:1.2.2'

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 }

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Nov 28 14:16:47 CET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
NDK  25.1.8937393 -> 25.2.9519653
AGP 7.1.0 -> 7.4.2
Gradle 7.6 -> 8.0
Kotlin 1.7.20 -> 1.8.10
Androidx Appcompat 1.6.0 -> 1.6.1
Androidx Exif Interface 1.3.5 -> 1.3.6
Material Components 1.7.0 -> 1.8.0
Androidx recyclerview 1.2.1 -> 1.3.0
Androidx viewmodel 2.5.1 -> 2.6.0

Based on following PR, modified for MMJR2
+ https://github.com/dolphin-emu/dolphin/pull/11571