### PR TITLE
CMake: Don't include SPIRV-Cross except on Windows and macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,7 +693,11 @@ endif()
 add_subdirectory(Externals/imgui)
 add_subdirectory(Externals/implot)
 add_subdirectory(Externals/glslang)
-add_subdirectory(Externals/spirv_cross)
+# SPIRV-Cross is used on Windows for GLSL to HLSL conversion for the Direct3D 11 and Direct3D 12
+# video backends, and on Apple devices for the Metal video backend.
+if(WIN32 OR APPLE)
+  add_subdirectory(Externals/spirv_cross)
+endif()
 
 if(ENABLE_VULKAN)
   add_definitions(-DHAS_VULKAN)

--- a/Source/Core/Common/CMakeLists.txt
+++ b/Source/Core/Common/CMakeLists.txt
@@ -299,7 +299,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_libraries(common PUBLIC dl rt)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(WIN32)
   target_sources(common PRIVATE HRWrap.h HRWrap.cpp)
 endif()
 

--- a/Source/Core/VideoBackends/CMakeLists.txt
+++ b/Source/Core/VideoBackends/CMakeLists.txt
@@ -2,7 +2,7 @@ add_subdirectory(OGL)
 add_subdirectory(Null)
 add_subdirectory(Software)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+if(WIN32)
   add_subdirectory(D3DCommon)
   add_subdirectory(D3D)
   add_subdirectory(D3D12)


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/11735