### PR TITLE
Common/IniFile: Move interface into Common namespace

### DIFF
--- a/Source/Android/jni/Cheats/ARCheat.cpp
+++ b/Source/Android/jni/Cheats/ARCheat.cpp
@@ -137,12 +137,12 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_ARCheat_loadCodes(JNIEnv* e
                                                                        jint revision)
 {
   const std::string game_id = GetJString(env, jGameID);
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
 
   // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
   // will always be stored in GS/${GAMEID}.ini
   game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + game_id + ".ini");
-  const IniFile game_ini_default = SConfig::LoadDefaultGameIni(game_id, revision);
+  const Common::IniFile game_ini_default = SConfig::LoadDefaultGameIni(game_id, revision);
 
   const std::vector<ActionReplay::ARCode> codes =
       ActionReplay::LoadCodes(game_ini_default, game_ini_local);
@@ -167,7 +167,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_cheats_model_ARCh
   const std::string game_id = GetJString(env, jGameID);
   const std::string ini_path = File::GetUserPath(D_GAMESETTINGS_IDX) + game_id + ".ini";
 
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
   game_ini_local.Load(ini_path);
   ActionReplay::SaveCodes(&game_ini_local, vector);
   game_ini_local.Save(ini_path);

--- a/Source/Android/jni/Cheats/GeckoCheat.cpp
+++ b/Source/Android/jni/Cheats/GeckoCheat.cpp
@@ -146,12 +146,12 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_GeckoCheat_loadCodes(JNIEnv
                                                                           jint revision)
 {
   const std::string game_id = GetJString(env, jGameID);
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
 
   // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
   // will always be stored in GS/${GAMEID}.ini
   game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + game_id + ".ini");
-  const IniFile game_ini_default = SConfig::LoadDefaultGameIni(game_id, revision);
+  const Common::IniFile game_ini_default = SConfig::LoadDefaultGameIni(game_id, revision);
 
   const std::vector<Gecko::GeckoCode> codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
 
@@ -175,7 +175,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_cheats_model_Geck
   const std::string game_id = GetJString(env, jGameID);
   const std::string ini_path = File::GetUserPath(D_GAMESETTINGS_IDX) + game_id + ".ini";
 
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
   game_ini_local.Load(ini_path);
   Gecko::SaveCodes(game_ini_local, vector);
   game_ini_local.Save(ini_path);

--- a/Source/Android/jni/Cheats/PatchCheat.cpp
+++ b/Source/Android/jni/Cheats/PatchCheat.cpp
@@ -124,12 +124,12 @@ Java_org_dolphinemu_dolphinemu_features_cheats_model_PatchCheat_loadCodes(JNIEnv
                                                                           jint revision)
 {
   const std::string game_id = GetJString(env, jGameID);
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
 
   // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
   // will always be stored in GS/${GAMEID}.ini
   game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + game_id + ".ini");
-  const IniFile game_ini_default = SConfig::LoadDefaultGameIni(game_id, revision);
+  const Common::IniFile game_ini_default = SConfig::LoadDefaultGameIni(game_id, revision);
 
   std::vector<PatchEngine::Patch> patches;
   PatchEngine::LoadPatchSection("OnFrame", &patches, game_ini_default, game_ini_local);
@@ -154,7 +154,7 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_cheats_model_Patc
   const std::string game_id = GetJString(env, jGameID);
   const std::string ini_path = File::GetUserPath(D_GAMESETTINGS_IDX) + game_id + ".ini";
 
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
   game_ini_local.Load(ini_path);
   PatchEngine::SavePatchSection(&game_ini_local, vector);
   game_ini_local.Save(ini_path);

--- a/Source/Android/jni/IniFile.cpp
+++ b/Source/Android/jni/IniFile.cpp
@@ -7,6 +7,8 @@
 #include "jni/AndroidCommon/AndroidCommon.h"
 #include "jni/AndroidCommon/IDCache.h"
 
+using Common::IniFile;
+
 static IniFile::Section* GetSectionPointer(JNIEnv* env, jobject obj)
 {
   return reinterpret_cast<IniFile::Section*>(

--- a/Source/Core/Common/IniFile.cpp
+++ b/Source/Core/Common/IniFile.cpp
@@ -15,6 +15,8 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtil.h"
 
+namespace Common
+{
 void IniFile::ParseLine(std::string_view line, std::string* keyOut, std::string* valueOut)
 {
   if (line.empty() || line.front() == '#')
@@ -369,3 +371,4 @@ bool IniFile::Save(const std::string& filename)
     return 0;
    }
  */
+}  // namespace Common

--- a/Source/Core/Common/IniFile.h
+++ b/Source/Core/Common/IniFile.h
@@ -13,6 +13,8 @@
 #include "Common/CommonTypes.h"
 #include "Common/StringUtil.h"
 
+namespace Common
+{
 struct CaseInsensitiveStringCompare
 {
   // Allow heterogenous lookup.
@@ -166,3 +168,4 @@ private:
 
   static const std::string& NULL_STRING;
 };
+}  // namespace Common

--- a/Source/Core/Core/ActionReplay.cpp
+++ b/Source/Core/Core/ActionReplay.cpp
@@ -169,18 +169,17 @@ void AddCode(ARCode code)
   }
 }
 
-void LoadAndApplyCodes(const IniFile& global_ini, const IniFile& local_ini)
+void LoadAndApplyCodes(const Common::IniFile& global_ini, const Common::IniFile& local_ini)
 {
   ApplyCodes(LoadCodes(global_ini, local_ini));
 }
 
 // Parses the Action Replay section of a game ini file.
-std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_ini)
+std::vector<ARCode> LoadCodes(const Common::IniFile& global_ini, const Common::IniFile& local_ini)
 {
   std::vector<ARCode> codes;
 
-  const IniFile* inis[2] = {&global_ini, &local_ini};
-  for (const IniFile* ini : inis)
+  for (const auto* ini : {&global_ini, &local_ini})
   {
     std::vector<std::string> lines;
     std::vector<std::string> encrypted_lines;
@@ -250,7 +249,7 @@ std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_in
   return codes;
 }
 
-void SaveCodes(IniFile* local_ini, std::span<const ARCode> codes)
+void SaveCodes(Common::IniFile* local_ini, std::span<const ARCode> codes)
 {
   std::vector<std::string> lines;
   std::vector<std::string> enabled_lines;

--- a/Source/Core/Core/ActionReplay.h
+++ b/Source/Core/Core/ActionReplay.h
@@ -10,7 +10,10 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Common
+{
 class IniFile;
+}
 
 namespace Core
 {
@@ -47,10 +50,10 @@ void SetSyncedCodesAsActive();
 void UpdateSyncedCodes(std::span<const ARCode> codes);
 std::vector<ARCode> ApplyAndReturnCodes(std::span<const ARCode> codes);
 void AddCode(ARCode new_code);
-void LoadAndApplyCodes(const IniFile& global_ini, const IniFile& local_ini);
+void LoadAndApplyCodes(const Common::IniFile& global_ini, const Common::IniFile& local_ini);
 
-std::vector<ARCode> LoadCodes(const IniFile& global_ini, const IniFile& local_ini);
-void SaveCodes(IniFile* local_ini, std::span<const ARCode> codes);
+std::vector<ARCode> LoadCodes(const Common::IniFile& global_ini, const Common::IniFile& local_ini);
+void SaveCodes(Common::IniFile* local_ini, std::span<const ARCode> codes);
 
 using EncryptedLine = std::string;
 std::variant<std::monostate, AREntry, EncryptedLine> DeserializeLine(const std::string& line);

--- a/Source/Core/Core/CheatCodes.h
+++ b/Source/Core/Core/CheatCodes.h
@@ -9,7 +9,7 @@
 #include "Common/IniFile.h"
 
 template <typename T>
-void ReadEnabledOrDisabled(const IniFile& ini, const std::string& section, bool enabled,
+void ReadEnabledOrDisabled(const Common::IniFile& ini, const std::string& section, bool enabled,
                            std::vector<T>* codes)
 {
   std::vector<std::string> lines;
@@ -30,7 +30,8 @@ void ReadEnabledOrDisabled(const IniFile& ini, const std::string& section, bool 
 }
 
 template <typename T>
-void ReadEnabledAndDisabled(const IniFile& ini, const std::string& section, std::vector<T>* codes)
+void ReadEnabledAndDisabled(const Common::IniFile& ini, const std::string& section,
+                            std::vector<T>* codes)
 {
   ReadEnabledOrDisabled(ini, section + "_Enabled", true, codes);
   ReadEnabledOrDisabled(ini, section + "_Disabled", false, codes);

--- a/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/BaseConfigLoader.cpp
@@ -113,14 +113,14 @@ public:
     LoadFromSYSCONF(layer);
     for (const auto& system : system_to_ini)
     {
-      IniFile ini;
+      Common::IniFile ini;
       ini.Load(File::GetUserPath(system.second));
-      const std::list<IniFile::Section>& system_sections = ini.GetSections();
+      const auto& system_sections = ini.GetSections();
 
       for (const auto& section : system_sections)
       {
         const std::string section_name = section.GetName();
-        const IniFile::Section::SectionMap& section_map = section.GetValues();
+        const auto& section_map = section.GetValues();
 
         for (const auto& value : section_map)
         {
@@ -141,7 +141,7 @@ public:
   {
     SaveToSYSCONF(layer->GetLayer());
 
-    std::map<Config::System, IniFile> inis;
+    std::map<Config::System, Common::IniFile> inis;
 
     for (const auto& system : system_to_ini)
     {
@@ -173,7 +173,7 @@ public:
 
       if (value)
       {
-        IniFile::Section* ini_section = ini->second.GetOrCreateSection(location.section);
+        auto* ini_section = ini->second.GetOrCreateSection(location.section);
         ini_section->Set(location.key, *value);
       }
       else

--- a/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
+++ b/Source/Core/Core/ConfigLoaders/GameConfigLoader.cpp
@@ -174,7 +174,7 @@ public:
 
   void Load(Config::Layer* layer) override
   {
-    IniFile ini;
+    Common::IniFile ini;
     if (layer->GetLayer() == Config::LayerType::GlobalGame)
     {
       for (const std::string& filename : GetGameIniFilenames(m_id, m_revision))
@@ -186,7 +186,7 @@ public:
         ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + filename, true);
     }
 
-    const std::list<IniFile::Section>& system_sections = ini.GetSections();
+    const auto& system_sections = ini.GetSections();
 
     for (const auto& section : system_sections)
     {
@@ -233,11 +233,11 @@ private:
             continue;
           }
 
-          IniFile profile_ini;
+          Common::IniFile profile_ini;
           profile_ini.Load(ini_path);
 
-          const IniFile::Section* ini_section = profile_ini.GetOrCreateSection("Profile");
-          const IniFile::Section::SectionMap& section_map = ini_section->GetValues();
+          const auto* ini_section = profile_ini.GetOrCreateSection("Profile");
+          const auto& section_map = ini_section->GetValues();
           for (const auto& value : section_map)
           {
             Config::Location location{std::get<2>(use_data), std::get<1>(use_data) + num,
@@ -249,12 +249,12 @@ private:
     }
   }
 
-  void LoadFromSystemSection(Config::Layer* layer, const IniFile::Section& section) const
+  void LoadFromSystemSection(Config::Layer* layer, const Common::IniFile::Section& section) const
   {
     const std::string section_name = section.GetName();
 
     // Regular key,value pairs
-    const IniFile::Section::SectionMap& section_map = section.GetValues();
+    const auto& section_map = section.GetValues();
 
     for (const auto& value : section_map)
     {
@@ -279,7 +279,7 @@ void INIGameConfigLayerLoader::Save(Config::Layer* layer)
   if (layer->GetLayer() != Config::LayerType::LocalGame)
     return;
 
-  IniFile ini;
+  Common::IniFile ini;
   for (const std::string& file_name : GetGameIniFilenames(m_id, m_revision))
     ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + file_name, true);
 
@@ -297,7 +297,7 @@ void INIGameConfigLayerLoader::Save(Config::Layer* layer)
 
     if (value)
     {
-      IniFile::Section* ini_section = ini.GetOrCreateSection(ini_location.first);
+      auto* ini_section = ini.GetOrCreateSection(ini_location.first);
       ini_section->Set(ini_location.second, *value);
     }
     else

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -393,40 +393,40 @@ DiscIO::Language SConfig::GetLanguageAdjustedForRegion(bool wii, DiscIO::Region 
   return language;
 }
 
-IniFile SConfig::LoadDefaultGameIni() const
+Common::IniFile SConfig::LoadDefaultGameIni() const
 {
   return LoadDefaultGameIni(GetGameID(), m_revision);
 }
 
-IniFile SConfig::LoadLocalGameIni() const
+Common::IniFile SConfig::LoadLocalGameIni() const
 {
   return LoadLocalGameIni(GetGameID(), m_revision);
 }
 
-IniFile SConfig::LoadGameIni() const
+Common::IniFile SConfig::LoadGameIni() const
 {
   return LoadGameIni(GetGameID(), m_revision);
 }
 
-IniFile SConfig::LoadDefaultGameIni(const std::string& id, std::optional<u16> revision)
+Common::IniFile SConfig::LoadDefaultGameIni(const std::string& id, std::optional<u16> revision)
 {
-  IniFile game_ini;
+  Common::IniFile game_ini;
   for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))
     game_ini.Load(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + filename, true);
   return game_ini;
 }
 
-IniFile SConfig::LoadLocalGameIni(const std::string& id, std::optional<u16> revision)
+Common::IniFile SConfig::LoadLocalGameIni(const std::string& id, std::optional<u16> revision)
 {
-  IniFile game_ini;
+  Common::IniFile game_ini;
   for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))
     game_ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + filename, true);
   return game_ini;
 }
 
-IniFile SConfig::LoadGameIni(const std::string& id, std::optional<u16> revision)
+Common::IniFile SConfig::LoadGameIni(const std::string& id, std::optional<u16> revision)
 {
-  IniFile game_ini;
+  Common::IniFile game_ini;
   for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))
     game_ini.Load(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + filename, true);
   for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(id, revision))

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -14,7 +14,10 @@
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
 
+namespace Common
+{
 class IniFile;
+}
 
 namespace Core
 {
@@ -81,13 +84,13 @@ struct SConfig
   DiscIO::Language GetCurrentLanguage(bool wii) const;
   DiscIO::Language GetLanguageAdjustedForRegion(bool wii, DiscIO::Region region) const;
 
-  IniFile LoadDefaultGameIni() const;
-  IniFile LoadLocalGameIni() const;
-  IniFile LoadGameIni() const;
+  Common::IniFile LoadDefaultGameIni() const;
+  Common::IniFile LoadLocalGameIni() const;
+  Common::IniFile LoadGameIni() const;
 
-  static IniFile LoadDefaultGameIni(const std::string& id, std::optional<u16> revision);
-  static IniFile LoadLocalGameIni(const std::string& id, std::optional<u16> revision);
-  static IniFile LoadGameIni(const std::string& id, std::optional<u16> revision);
+  static Common::IniFile LoadDefaultGameIni(const std::string& id, std::optional<u16> revision);
+  static Common::IniFile LoadLocalGameIni(const std::string& id, std::optional<u16> revision);
+  static Common::IniFile LoadGameIni(const std::string& id, std::optional<u16> revision);
 
   SConfig(const SConfig&) = delete;
   SConfig& operator=(const SConfig&) = delete;

--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -127,11 +127,11 @@ std::vector<GeckoCode> DownloadCodes(std::string gametdb_id, bool* succeeded, bo
   return gcodes;
 }
 
-std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni)
+std::vector<GeckoCode> LoadCodes(const Common::IniFile& globalIni, const Common::IniFile& localIni)
 {
   std::vector<GeckoCode> gcodes;
 
-  for (const IniFile* ini : {&globalIni, &localIni})
+  for (const auto* ini : {&globalIni, &localIni})
   {
     std::vector<std::string> lines;
     ini->GetLines("Gecko", &lines, false);
@@ -239,7 +239,7 @@ static void SaveGeckoCode(std::vector<std::string>& lines, const GeckoCode& gcod
     lines.push_back('*' + note);
 }
 
-void SaveCodes(IniFile& inifile, const std::vector<GeckoCode>& gcodes)
+void SaveCodes(Common::IniFile& inifile, const std::vector<GeckoCode>& gcodes)
 {
   std::vector<std::string> lines;
   std::vector<std::string> enabled_lines;

--- a/Source/Core/Core/GeckoCodeConfig.h
+++ b/Source/Core/Core/GeckoCodeConfig.h
@@ -9,14 +9,17 @@
 
 #include "Core/GeckoCode.h"
 
+namespace Common
+{
 class IniFile;
+}
 
 namespace Gecko
 {
-std::vector<GeckoCode> LoadCodes(const IniFile& globalIni, const IniFile& localIni);
+std::vector<GeckoCode> LoadCodes(const Common::IniFile& globalIni, const Common::IniFile& localIni);
 std::vector<GeckoCode> DownloadCodes(std::string gametdb_id, bool* succeeded,
                                      bool use_https = true);
-void SaveCodes(IniFile& inifile, const std::vector<GeckoCode>& gcodes);
+void SaveCodes(Common::IniFile& inifile, const std::vector<GeckoCode>& gcodes);
 
 std::optional<GeckoCode::Code> DeserializeLine(const std::string& line);
 }  // namespace Gecko

--- a/Source/Core/Core/HotkeyManager.cpp
+++ b/Source/Core/Core/HotkeyManager.cpp
@@ -251,7 +251,7 @@ bool IsPressed(int id, bool held)
 // TODO: Remove this at a future date when we're confident most configs are migrated.
 static void LoadLegacyConfig(ControllerEmu::EmulatedController* controller)
 {
-  IniFile inifile;
+  Common::IniFile inifile;
   if (inifile.Load(File::GetUserPath(D_CONFIG_IDX) + "Hotkeys.ini"))
   {
     if (!inifile.Exists("Hotkeys") && inifile.Exists("Hotkeys1"))

--- a/Source/Core/Core/IOS/USB/USB_KBD.cpp
+++ b/Source/Core/Core/IOS/USB/USB_KBD.cpp
@@ -191,7 +191,7 @@ USB_KBD::USB_KBD(Kernel& ios, const std::string& device_name) : Device(ios, devi
 std::optional<IPCReply> USB_KBD::Open(const OpenRequest& request)
 {
   INFO_LOG_FMT(IOS, "USB_KBD: Open");
-  IniFile ini;
+  Common::IniFile ini;
   ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
   ini.GetOrCreateSection("USB Keyboard")->Get("Layout", &m_keyboard_layout, KBD_LAYOUT_QWERTY);
 

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -2027,10 +2027,10 @@ bool NetPlayServer::SyncCodes()
   // Find all INI files
   const auto game_id = game->GetGameID();
   const auto revision = game->GetRevision();
-  IniFile globalIni;
+  Common::IniFile globalIni;
   for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(game_id, revision))
     globalIni.Load(File::GetSysDirectory() + GAMESETTINGS_DIR DIR_SEP + filename, true);
-  IniFile localIni;
+  Common::IniFile localIni;
   for (const std::string& filename : ConfigLoaders::GetGameIniFilenames(game_id, revision))
     localIni.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + filename, true);
 

--- a/Source/Core/Core/PatchEngine.cpp
+++ b/Source/Core/Core/PatchEngine.cpp
@@ -101,11 +101,9 @@ std::string SerializeLine(const PatchEntry& entry)
 }
 
 void LoadPatchSection(const std::string& section, std::vector<Patch>* patches,
-                      const IniFile& globalIni, const IniFile& localIni)
+                      const Common::IniFile& globalIni, const Common::IniFile& localIni)
 {
-  const IniFile* inis[2] = {&globalIni, &localIni};
-
-  for (const IniFile* ini : inis)
+  for (const auto* ini : {&globalIni, &localIni})
   {
     std::vector<std::string> lines;
     Patch currentPatch;
@@ -151,7 +149,7 @@ void LoadPatchSection(const std::string& section, std::vector<Patch>* patches,
   }
 }
 
-void SavePatchSection(IniFile* local_ini, const std::vector<Patch>& patches)
+void SavePatchSection(Common::IniFile* local_ini, const std::vector<Patch>& patches)
 {
   std::vector<std::string> lines;
   std::vector<std::string> lines_enabled;
@@ -176,7 +174,7 @@ void SavePatchSection(IniFile* local_ini, const std::vector<Patch>& patches)
   local_ini->SetLines("OnFrame", lines);
 }
 
-static void LoadSpeedhacks(const std::string& section, IniFile& ini)
+static void LoadSpeedhacks(const std::string& section, Common::IniFile& ini)
 {
   std::vector<std::string> keys;
   ini.GetKeys(section, &keys);
@@ -210,9 +208,10 @@ int GetSpeedhackCycles(const u32 addr)
 
 void LoadPatches()
 {
-  IniFile merged = SConfig::GetInstance().LoadGameIni();
-  IniFile globalIni = SConfig::GetInstance().LoadDefaultGameIni();
-  IniFile localIni = SConfig::GetInstance().LoadLocalGameIni();
+  const auto& sconfig = SConfig::GetInstance();
+  Common::IniFile merged = sconfig.LoadGameIni();
+  Common::IniFile globalIni = sconfig.LoadDefaultGameIni();
+  Common::IniFile localIni = sconfig.LoadLocalGameIni();
 
   LoadPatchSection("OnFrame", &s_on_frame, globalIni, localIni);
 

--- a/Source/Core/Core/PatchEngine.h
+++ b/Source/Core/Core/PatchEngine.h
@@ -9,7 +9,10 @@
 
 #include "Common/CommonTypes.h"
 
+namespace Common
+{
 class IniFile;
+}
 
 namespace PatchEngine
 {
@@ -47,8 +50,8 @@ int GetSpeedhackCycles(const u32 addr);
 std::optional<PatchEntry> DeserializeLine(std::string line);
 std::string SerializeLine(const PatchEntry& entry);
 void LoadPatchSection(const std::string& section, std::vector<Patch>* patches,
-                      const IniFile& globalIni, const IniFile& localIni);
-void SavePatchSection(IniFile* local_ini, const std::vector<Patch>& patches);
+                      const Common::IniFile& globalIni, const Common::IniFile& localIni);
+void SavePatchSection(Common::IniFile* local_ini, const std::vector<Patch>& patches);
 void LoadPatches();
 
 void AddMemoryPatch(std::size_t index);

--- a/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/ARCodeWidget.cpp
@@ -32,13 +32,14 @@ ARCodeWidget::ARCodeWidget(std::string game_id, u16 game_revision, bool restart_
 
   if (!m_game_id.empty())
   {
-    IniFile game_ini_local;
+    Common::IniFile game_ini_local;
 
     // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
     // will always be stored in GS/${GAMEID}.ini
     game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
 
-    const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
+    const Common::IniFile game_ini_default =
+        SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
     m_ar_codes = ActionReplay::LoadCodes(game_ini_default, game_ini_local);
   }
 
@@ -184,7 +185,7 @@ void ARCodeWidget::SaveCodes()
   const auto ini_path =
       std::string(File::GetUserPath(D_GAMESETTINGS_IDX)).append(m_game_id).append(".ini");
 
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
   game_ini_local.Load(ini_path);
   ActionReplay::SaveCodes(&game_ini_local, m_ar_codes);
   game_ini_local.Save(ini_path);

--- a/Source/Core/DolphinQt/Config/GameConfigWidget.h
+++ b/Source/Core/DolphinQt/Config/GameConfigWidget.h
@@ -63,6 +63,6 @@ private:
   const UICommon::GameFile& m_game;
   std::string m_game_id;
 
-  IniFile m_gameini_local;
-  IniFile m_gameini_default;
+  Common::IniFile m_gameini_local;
+  Common::IniFile m_gameini_default;
 };

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -39,13 +39,14 @@ GeckoCodeWidget::GeckoCodeWidget(std::string game_id, std::string gametdb_id, u1
 
   if (!m_game_id.empty())
   {
-    IniFile game_ini_local;
+    Common::IniFile game_ini_local;
 
     // We don't use LoadLocalGameIni() here because user cheat codes that are installed via the UI
     // will always be stored in GS/${GAMEID}.ini
     game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
 
-    const IniFile game_ini_default = SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
+    const Common::IniFile game_ini_default =
+        SConfig::LoadDefaultGameIni(m_game_id, m_game_revision);
     m_gecko_codes = Gecko::LoadCodes(game_ini_default, game_ini_local);
   }
 
@@ -244,7 +245,7 @@ void GeckoCodeWidget::SaveCodes()
   const auto ini_path =
       std::string(File::GetUserPath(D_GAMESETTINGS_IDX)).append(m_game_id).append(".ini");
 
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
   game_ini_local.Load(ini_path);
   Gecko::SaveCodes(game_ini_local, m_gecko_codes);
   game_ini_local.Save(ini_path);

--- a/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
+++ b/Source/Core/DolphinQt/Config/Mapping/MappingWindow.cpp
@@ -298,7 +298,7 @@ void MappingWindow::OnLoadProfilePressed()
 
   const QString profile_path = m_profiles_combo->currentData().toString();
 
-  IniFile ini;
+  Common::IniFile ini;
   ini.Load(profile_path.toStdString());
 
   m_controller->LoadConfig(ini.GetOrCreateSection("Profile"));
@@ -321,7 +321,7 @@ void MappingWindow::OnSaveProfilePressed()
 
   File::CreateFullPath(profile_path);
 
-  IniFile ini;
+  Common::IniFile ini;
 
   m_controller->SaveConfig(ini.GetOrCreateSection("Profile"));
   ini.Save(profile_path);
@@ -541,7 +541,7 @@ void MappingWindow::OnDefaultFieldsPressed()
 void MappingWindow::OnClearFieldsPressed()
 {
   // Loading an empty inifile section clears everything.
-  IniFile::Section sec;
+  Common::IniFile::Section sec;
 
   // Keep the currently selected device.
   const auto default_device = m_controller->GetDefaultDevice();

--- a/Source/Core/DolphinQt/Config/PatchesWidget.cpp
+++ b/Source/Core/DolphinQt/Config/PatchesWidget.cpp
@@ -21,10 +21,11 @@
 PatchesWidget::PatchesWidget(const UICommon::GameFile& game)
     : m_game_id(game.GetGameID()), m_game_revision(game.GetRevision())
 {
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
   game_ini_local.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini");
 
-  IniFile game_ini_default = SConfig::GetInstance().LoadDefaultGameIni(m_game_id, m_game_revision);
+  Common::IniFile game_ini_default =
+      SConfig::GetInstance().LoadDefaultGameIni(m_game_id, m_game_revision);
 
   PatchEngine::LoadPatchSection("OnFrame", &m_patches, game_ini_default, game_ini_local);
 
@@ -128,7 +129,7 @@ void PatchesWidget::SavePatches()
 {
   const std::string ini_path = File::GetUserPath(D_GAMESETTINGS_IDX) + m_game_id + ".ini";
 
-  IniFile game_ini_local;
+  Common::IniFile game_ini_local;
   game_ini_local.Load(ini_path);
   PatchEngine::SavePatchSection(&game_ini_local, m_patches);
   game_ini_local.Save(ini_path);

--- a/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/BreakpointWidget.cpp
@@ -337,7 +337,7 @@ void BreakpointWidget::OnEditBreakpoint(u32 address, bool is_instruction_bp)
 
 void BreakpointWidget::OnLoad()
 {
-  IniFile ini;
+  Common::IniFile ini;
   if (!ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + SConfig::GetInstance().GetGameID() + ".ini",
                 false))
   {
@@ -367,7 +367,7 @@ void BreakpointWidget::OnLoad()
 
 void BreakpointWidget::OnSave()
 {
-  IniFile ini;
+  Common::IniFile ini;
   ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + SConfig::GetInstance().GetGameID() + ".ini",
            false);
   ini.SetLines("BreakPoints", m_system.GetPowerPC().GetBreakPoints().GetStrings());

--- a/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
+++ b/Source/Core/DolphinQt/Debugger/WatchWidget.cpp
@@ -289,7 +289,7 @@ void WatchWidget::OnNewWatch()
 
 void WatchWidget::OnLoad()
 {
-  IniFile ini;
+  Common::IniFile ini;
 
   std::vector<std::string> watches;
 
@@ -317,7 +317,7 @@ void WatchWidget::OnLoad()
 
 void WatchWidget::OnSave()
 {
-  IniFile ini;
+  Common::IniFile ini;
   ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + SConfig::GetInstance().GetGameID() + ".ini",
            false);
   ini.SetLines("Watches", m_system.GetPowerPC().GetDebugInterface().SaveWatchesToStrings());

--- a/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
+++ b/Source/Core/DolphinQt/TAS/WiiTASInputWindow.cpp
@@ -255,7 +255,7 @@ WiiTASInputWindow::WiiTASInputWindow(QWidget* parent, int num) : TASInputWindow(
   }
   else
   {
-    IniFile ini;
+    Common::IniFile ini;
     ini.Load(File::GetUserPath(D_CONFIG_IDX) + "WiimoteNew.ini");
     std::string extension;
     ini.GetIfExists("Wiimote" + std::to_string(num + 1), "Extension", &extension);

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.cpp
@@ -50,7 +50,7 @@ void ControlGroup::AddDeadzoneSetting(SettingValue<double>* value, double maximu
 
 ControlGroup::~ControlGroup() = default;
 
-void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
+void ControlGroup::LoadConfig(Common::IniFile::Section* sec, const std::string& defdev,
                               const std::string& base)
 {
   const std::string group(base + name + "/");
@@ -103,7 +103,7 @@ void ControlGroup::LoadConfig(IniFile::Section* sec, const std::string& defdev,
   }
 }
 
-void ControlGroup::SaveConfig(IniFile::Section* sec, const std::string& defdev,
+void ControlGroup::SaveConfig(Common::IniFile::Section* sec, const std::string& defdev,
                               const std::string& base)
 {
   const std::string group(base + name + "/");

--- a/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControlGroup/ControlGroup.h
@@ -61,9 +61,9 @@ public:
                DefaultValue default_value = DefaultValue::AlwaysEnabled);
   virtual ~ControlGroup();
 
-  virtual void LoadConfig(IniFile::Section* sec, const std::string& defdev = "",
+  virtual void LoadConfig(Common::IniFile::Section* sec, const std::string& defdev = "",
                           const std::string& base = "");
-  virtual void SaveConfig(IniFile::Section* sec, const std::string& defdev = "",
+  virtual void SaveConfig(Common::IniFile::Section* sec, const std::string& defdev = "",
                           const std::string& base = "");
 
   void SetControlExpression(int index, const std::string& expression);

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.cpp
@@ -138,7 +138,7 @@ void EmulatedController::SetDefaultDevice(ciface::Core::DeviceQualifier devq)
   }
 }
 
-void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& base)
+void EmulatedController::LoadConfig(Common::IniFile::Section* sec, const std::string& base)
 {
   const auto lock = GetStateLock();
   std::string defdev = GetDefaultDevice().ToString();
@@ -152,7 +152,7 @@ void EmulatedController::LoadConfig(IniFile::Section* sec, const std::string& ba
     cg->LoadConfig(sec, defdev, base);
 }
 
-void EmulatedController::SaveConfig(IniFile::Section* sec, const std::string& base)
+void EmulatedController::SaveConfig(Common::IniFile::Section* sec, const std::string& base)
 {
   const auto lock = GetStateLock();
   const std::string defdev = GetDefaultDevice().ToString();
@@ -167,7 +167,7 @@ void EmulatedController::LoadDefaults(const ControllerInterface& ciface)
 {
   const auto lock = GetStateLock();
   // load an empty inifile section, clears everything
-  IniFile::Section sec;
+  Common::IniFile::Section sec;
   LoadConfig(&sec);
 
   const std::string& default_device_string = ciface.GetDefaultDeviceString();

--- a/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
+++ b/Source/Core/InputCommon/ControllerEmu/ControllerEmu.h
@@ -176,8 +176,8 @@ public:
 
   virtual void LoadDefaults(const ControllerInterface& ciface);
 
-  virtual void LoadConfig(IniFile::Section* sec, const std::string& base = "");
-  virtual void SaveConfig(IniFile::Section* sec, const std::string& base = "");
+  virtual void LoadConfig(Common::IniFile::Section* sec, const std::string& base = "");
+  virtual void SaveConfig(Common::IniFile::Section* sec, const std::string& base = "");
 
   bool IsDefaultDeviceConnected() const;
   const ciface::Core::DeviceQualifier& GetDefaultDevice() const;

--- a/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
+++ b/Source/Core/InputCommon/ControllerEmu/Setting/NumericSetting.h
@@ -60,8 +60,10 @@ public:
 
   virtual ~NumericSettingBase() = default;
 
-  virtual void LoadFromIni(const IniFile::Section& section, const std::string& group_name) = 0;
-  virtual void SaveToIni(IniFile::Section& section, const std::string& group_name) const = 0;
+  virtual void LoadFromIni(const Common::IniFile::Section& section,
+                           const std::string& group_name) = 0;
+  virtual void SaveToIni(Common::IniFile::Section& section,
+                         const std::string& group_name) const = 0;
 
   virtual InputReference& GetInputReference() = 0;
   virtual const InputReference& GetInputReference() const = 0;
@@ -110,7 +112,7 @@ public:
 
   void SetToDefault() override { m_value.SetValue(m_default_value); }
 
-  void LoadFromIni(const IniFile::Section& section, const std::string& group_name) override
+  void LoadFromIni(const Common::IniFile::Section& section, const std::string& group_name) override
   {
     std::string str_value;
     if (section.Get(group_name + m_details.ini_name, &str_value))
@@ -124,7 +126,7 @@ public:
     }
   }
 
-  void SaveToIni(IniFile::Section& section, const std::string& group_name) const override
+  void SaveToIni(Common::IniFile::Section& section, const std::string& group_name) const override
   {
     if (IsSimpleValue())
     {

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.cpp
@@ -226,8 +226,8 @@ void ReshapableInput::SetCenter(ReshapableInput::ReshapeData center)
   m_center = center;
 }
 
-void ReshapableInput::LoadConfig(IniFile::Section* section, const std::string& default_device,
-                                 const std::string& base_name)
+void ReshapableInput::LoadConfig(Common::IniFile::Section* section,
+                                 const std::string& default_device, const std::string& base_name)
 {
   ControlGroup::LoadConfig(section, default_device, base_name);
 
@@ -269,8 +269,8 @@ void ReshapableInput::LoadConfig(IniFile::Section* section, const std::string& d
   }
 }
 
-void ReshapableInput::SaveConfig(IniFile::Section* section, const std::string& default_device,
-                                 const std::string& base_name)
+void ReshapableInput::SaveConfig(Common::IniFile::Section* section,
+                                 const std::string& default_device, const std::string& base_name)
 {
   ControlGroup::SaveConfig(section, default_device, base_name);
 

--- a/Source/Core/InputCommon/ControllerEmu/StickGate.h
+++ b/Source/Core/InputCommon/ControllerEmu/StickGate.h
@@ -113,8 +113,8 @@ protected:
   virtual Control* GetModifierInput() const;
 
 private:
-  void LoadConfig(IniFile::Section*, const std::string&, const std::string&) override;
-  void SaveConfig(IniFile::Section*, const std::string&, const std::string&) override;
+  void LoadConfig(Common::IniFile::Section*, const std::string&, const std::string&) override;
+  void SaveConfig(Common::IniFile::Section*, const std::string&, const std::string&) override;
 
   CalibrationData m_calibration;
   SettingValue<double> m_deadzone_setting;

--- a/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
@@ -641,7 +641,7 @@ void Init(const std::string& game_id)
             new sBind(a, WIIMOTE_GYRO_YAW_RIGHT, BIND_AXIS, WIIMOTE_GYRO_YAW_RIGHT, -1.0f));
   }
   // Init our controller bindings
-  IniFile ini;
+  Common::IniFile ini;
   ini.Load(File::GetUserPath(D_CONFIG_IDX) + std::string("Dolphin.ini"), true);
   ini.Load(File::GetUserPath(D_GAMESETTINGS_IDX) + std::string(game_id + ".ini"), true);
   for (u32 a = 0; a < CONFIG_STRINGS.size(); ++a)

--- a/Source/Core/InputCommon/DynamicInputTextureManager.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextureManager.cpp
@@ -39,7 +39,7 @@ void DynamicInputTextureManager::Load()
   }
 }
 
-void DynamicInputTextureManager::GenerateTextures(const IniFile& file,
+void DynamicInputTextureManager::GenerateTextures(const Common::IniFile& file,
                                                   const std::vector<std::string>& controller_names)
 {
   bool any_dirty = false;

--- a/Source/Core/InputCommon/DynamicInputTextureManager.h
+++ b/Source/Core/InputCommon/DynamicInputTextureManager.h
@@ -20,7 +20,8 @@ public:
   DynamicInputTextureManager();
   ~DynamicInputTextureManager();
   void Load();
-  void GenerateTextures(const IniFile& file, const std::vector<std::string>& controller_names);
+  void GenerateTextures(const Common::IniFile& file,
+                        const std::vector<std::string>& controller_names);
 
 private:
   std::vector<DynamicInputTextures::Configuration> m_configuration;

--- a/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.cpp
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.cpp
@@ -11,6 +11,7 @@
 
 #include "Common/CommonPaths.h"
 #include "Common/FileUtil.h"
+#include "Common/IniFile.h"
 #include "Common/Logging/Log.h"
 #include "Common/StringUtil.h"
 #include "Core/ConfigManager.h"
@@ -86,7 +87,7 @@ Configuration::Configuration(const std::string& json_file)
 
 Configuration::~Configuration() = default;
 
-bool Configuration::GenerateTextures(const IniFile& file,
+bool Configuration::GenerateTextures(const Common::IniFile& file,
                                      const std::vector<std::string>& controller_names) const
 {
   bool any_dirty = false;
@@ -98,7 +99,7 @@ bool Configuration::GenerateTextures(const IniFile& file,
   return any_dirty;
 }
 
-bool Configuration::GenerateTexture(const IniFile& file,
+bool Configuration::GenerateTexture(const Common::IniFile& file,
                                     const std::vector<std::string>& controller_names,
                                     const Data& texture_data) const
 {

--- a/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
+++ b/Source/Core/InputCommon/DynamicInputTextures/DITConfiguration.h
@@ -4,12 +4,15 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "Common/CommonTypes.h"
-#include "Common/IniFile.h"
 #include "InputCommon/DynamicInputTextures/DITData.h"
+
+namespace Common
+{
+class IniFile;
+}
 
 namespace InputCommon::DynamicInputTextures
 {
@@ -18,11 +21,12 @@ class Configuration
 public:
   explicit Configuration(const std::string& json_file);
   ~Configuration();
-  bool GenerateTextures(const IniFile& file,
+  bool GenerateTextures(const Common::IniFile& file,
                         const std::vector<std::string>& controller_names) const;
 
 private:
-  bool GenerateTexture(const IniFile& file, const std::vector<std::string>& controller_names,
+  bool GenerateTexture(const Common::IniFile& file,
+                       const std::vector<std::string>& controller_names,
                        const Data& texture_data) const;
 
   std::vector<Data> m_dynamic_input_textures;

--- a/Source/Core/InputCommon/InputConfig.cpp
+++ b/Source/Core/InputCommon/InputConfig.cpp
@@ -29,7 +29,7 @@ InputConfig::~InputConfig() = default;
 
 bool InputConfig::LoadConfig(InputClass type)
 {
-  IniFile inifile;
+  Common::IniFile inifile;
   bool useProfile[MAX_BBMOTES] = {false, false, false, false, false};
   static constexpr std::array<std::string_view, MAX_BBMOTES> num = {"1", "2", "3", "4", "BB"};
   std::string profile[MAX_BBMOTES];
@@ -62,8 +62,8 @@ bool InputConfig::LoadConfig(InputClass type)
       break;
     }
 
-    IniFile game_ini = SConfig::GetInstance().LoadGameIni();
-    IniFile::Section* control_section = game_ini.GetOrCreateSection("Controls");
+    Common::IniFile game_ini = SConfig::GetInstance().LoadGameIni();
+    auto* control_section = game_ini.GetOrCreateSection("Controls");
 
     for (int i = 0; i < 4; i++)
     {
@@ -112,7 +112,7 @@ bool InputConfig::LoadConfig(InputClass type)
     std::vector<std::string> controller_names;
     for (auto& controller : m_controllers)
     {
-      IniFile::Section config;
+      Common::IniFile::Section config;
       // Load settings from ini
       if (useProfile[n])
       {
@@ -172,7 +172,7 @@ void InputConfig::SaveConfig()
 {
   std::string ini_filename = File::GetUserPath(D_CONFIG_IDX) + m_ini_name + ".ini";
 
-  IniFile inifile;
+  Common::IniFile inifile;
   inifile.Load(ini_filename);
 
   std::vector<std::string> controller_names;
@@ -238,7 +238,7 @@ bool InputConfig::IsControllerControlledByGamepadDevice(int index) const
                controller.name == "Keyboard Mouse"));  // Windows Keyboard/Mouse
 }
 
-void InputConfig::GenerateControllerTextures(const IniFile& file)
+void InputConfig::GenerateControllerTextures(const Common::IniFile& file)
 {
   std::vector<std::string> controller_names;
   for (auto& controller : m_controllers)

--- a/Source/Core/InputCommon/InputConfig.h
+++ b/Source/Core/InputCommon/InputConfig.h
@@ -11,6 +11,11 @@
 #include "InputCommon/ControllerInterface/ControllerInterface.h"
 #include "InputCommon/DynamicInputTextureManager.h"
 
+namespace Common
+{
+class IniFile;
+}
+
 namespace ControllerEmu
 {
 class EmulatedController;
@@ -53,7 +58,7 @@ public:
   void RegisterHotplugCallback();
   void UnregisterHotplugCallback();
 
-  void GenerateControllerTextures(const IniFile& file);
+  void GenerateControllerTextures(const Common::IniFile& file);
 
 private:
   ControllerInterface::HotplugCallbackHandle m_hotplug_callback_handle;

--- a/Source/Core/InputCommon/InputProfile.cpp
+++ b/Source/Core/InputCommon/InputProfile.cpp
@@ -78,7 +78,7 @@ void ProfileCycler::UpdateToProfile(const std::string& profile_filename,
   std::string base;
   SplitPath(profile_filename, nullptr, &base, nullptr);
 
-  IniFile ini_file;
+  Common::IniFile ini_file;
   if (ini_file.Load(profile_filename))
   {
     Core::DisplayMessage("Loading input profile '" + base + "' for device '" +
@@ -180,8 +180,8 @@ void ProfileCycler::CycleProfileForGame(CycleDirection cycle_direction,
 
 std::string ProfileCycler::GetWiimoteInputProfilesForGame(int controller_index)
 {
-  IniFile game_ini = SConfig::GetInstance().LoadGameIni();
-  const IniFile::Section* const control_section = game_ini.GetOrCreateSection("Controls");
+  Common::IniFile game_ini = SConfig::GetInstance().LoadGameIni();
+  const auto* const control_section = game_ini.GetOrCreateSection("Controls");
 
   std::string result;
   control_section->Get(fmt::format("WiimoteProfile{}", controller_index + 1), &result);

--- a/Source/Core/UICommon/ResourcePack/Manager.cpp
+++ b/Source/Core/UICommon/ResourcePack/Manager.cpp
@@ -17,11 +17,11 @@ namespace
 std::vector<ResourcePack> packs;
 std::string packs_path;
 
-IniFile GetPackConfig()
+Common::IniFile GetPackConfig()
 {
   packs_path = File::GetUserPath(D_RESOURCEPACK_IDX) + "/Packs.ini";
 
-  IniFile file;
+  Common::IniFile file;
   file.Load(packs_path);
 
   return file;
@@ -34,7 +34,7 @@ bool Init()
   const std::vector<std::string> pack_list =
       Common::DoFileSearch({File::GetUserPath(D_RESOURCEPACK_IDX)}, {".zip"});
 
-  IniFile file = GetPackConfig();
+  Common::IniFile file = GetPackConfig();
 
   auto* order = file.GetOrCreateSection("Order");
 
@@ -123,7 +123,7 @@ ResourcePack* Add(const std::string& path, int offset)
   if (!pack.IsValid())
     return nullptr;
 
-  IniFile file = GetPackConfig();
+  Common::IniFile file = GetPackConfig();
 
   auto* order = file.GetOrCreateSection("Order");
 
@@ -150,7 +150,7 @@ bool Remove(ResourcePack& pack)
   if (pack_iterator == packs.end())
     return false;
 
-  IniFile file = GetPackConfig();
+  Common::IniFile file = GetPackConfig();
 
   auto* order = file.GetOrCreateSection("Order");
 
@@ -170,7 +170,7 @@ bool Remove(ResourcePack& pack)
 
 void SetInstalled(const ResourcePack& pack, bool installed)
 {
-  IniFile file = GetPackConfig();
+  Common::IniFile file = GetPackConfig();
 
   auto* install = file.GetOrCreateSection("Installed");
 
@@ -184,7 +184,7 @@ void SetInstalled(const ResourcePack& pack, bool installed)
 
 bool IsInstalled(const ResourcePack& pack)
 {
-  IniFile file = GetPackConfig();
+  Common::IniFile file = GetPackConfig();
 
   auto* install = file.GetOrCreateSection("Installed");
 

--- a/Source/Core/VideoCommon/PostProcessing.cpp
+++ b/Source/Core/VideoCommon/PostProcessing.cpp
@@ -151,7 +151,7 @@ void PostProcessingConfiguration::LoadOptions(const std::string& code)
           if (current_strings)
           {
             std::string key, value;
-            IniFile::ParseLine(line, &key, &value);
+            Common::IniFile::ParseLine(line, &key, &value);
 
             if (!(key.empty() && value.empty()))
               current_strings->m_options.emplace_back(key, value);
@@ -238,7 +238,7 @@ void PostProcessingConfiguration::LoadOptions(const std::string& code)
 
 void PostProcessingConfiguration::LoadOptionsConfiguration()
 {
-  IniFile ini;
+  Common::IniFile ini;
   ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
   std::string section = m_current_shader + "-options";
 
@@ -272,7 +272,7 @@ void PostProcessingConfiguration::LoadOptionsConfiguration()
 
 void PostProcessingConfiguration::SaveOptionsConfiguration()
 {
-  IniFile ini;
+  Common::IniFile ini;
   ini.Load(File::GetUserPath(F_DOLPHINCONFIG_IDX));
   std::string section = m_current_shader + "-options";
 


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/11756

Since MMJR2 doesn´t went with Android Input overhaul, the changes to EmulatedController.cpp from the original commit were discarded. For the same reason there was an IniFile class in ButtonManager.cpp so I moved it to Common namespace there as well.