### PR TITLE
OGL: Only specify precision for sampler2DMSArray when it is defined

### DIFF
--- a/Source/Core/VideoBackends/OGL/OGLConfig.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.cpp
@@ -368,9 +368,10 @@ bool PopulateConfig(GLContext* m_main_gl_context)
 
   if (m_main_gl_context->IsGLES())
   {
-    g_ogl_config.SupportedESPointSize = GLExtensions::Supports("GL_OES_geometry_point_size") ? 1 :
-                                        GLExtensions::Supports("GL_EXT_geometry_point_size") ? 2 :
-                                                                                               0;
+    g_ogl_config.SupportedESPointSize =
+        GLExtensions::Supports("GL_OES_geometry_point_size") ? EsPointSizeType::PointSizeOes :
+        GLExtensions::Supports("GL_EXT_geometry_point_size") ? EsPointSizeType::PointSizeExt :
+                                                               EsPointSizeType::PointSizeNone;
     g_ogl_config.SupportedESTextureBuffer =
         GLExtensions::Supports("VERSION_GLES_3_2")      ? EsTexbufType::TexbufCore :
         GLExtensions::Supports("GL_OES_texture_buffer") ? EsTexbufType::TexbufOes :
@@ -410,7 +411,8 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       g_Config.backend_info.bSupportsGeometryShaders = g_ogl_config.bSupportsAEP;
       g_Config.backend_info.bSupportsComputeShaders = true;
       g_Config.backend_info.bSupportsGSInstancing =
-          g_Config.backend_info.bSupportsGeometryShaders && g_ogl_config.SupportedESPointSize > 0;
+          g_Config.backend_info.bSupportsGeometryShaders &&
+          g_ogl_config.SupportedESPointSize != EsPointSizeType::PointSizeNone;
       g_Config.backend_info.bSupportsSSAA = g_ogl_config.bSupportsAEP;
       g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
       g_ogl_config.bSupportsMSAA = true;
@@ -434,7 +436,8 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       g_ogl_config.bSupportsImageLoadStore = true;
       g_Config.backend_info.bSupportsGeometryShaders = true;
       g_Config.backend_info.bSupportsComputeShaders = true;
-      g_Config.backend_info.bSupportsGSInstancing = g_ogl_config.SupportedESPointSize > 0;
+      g_Config.backend_info.bSupportsGSInstancing =
+          g_ogl_config.SupportedESPointSize != EsPointSizeType::PointSizeNone;
       g_Config.backend_info.bSupportsPaletteConversion = true;
       g_Config.backend_info.bSupportsSSAA = true;
       g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;

--- a/Source/Core/VideoBackends/OGL/OGLConfig.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.cpp
@@ -333,6 +333,7 @@ bool PopulateConfig(GLContext* m_main_gl_context)
   g_ogl_config.bSupportsDebug =
       GLExtensions::Supports("GL_KHR_debug") || GLExtensions::Supports("GL_ARB_debug_output");
   g_ogl_config.bSupportsTextureStorage = GLExtensions::Supports("GL_ARB_texture_storage");
+  g_ogl_config.SupportedMultisampleTexStorage = MultisampleTexStorageType::TexStorageNone;
   g_ogl_config.bSupportsImageLoadStore = GLExtensions::Supports("GL_ARB_shader_image_load_store");
   g_ogl_config.bSupportsConservativeDepth = GLExtensions::Supports("GL_ARB_conservative_depth");
   g_ogl_config.bSupportsAniso = GLExtensions::Supports("GL_EXT_texture_filter_anisotropic");
@@ -412,6 +413,8 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
       g_ogl_config.bSupportsMSAA = true;
       g_ogl_config.bSupportsTextureStorage = true;
+      if (GLExtensions::Supports("GL_OES_texture_storage_multisample_2d_array"))
+        g_ogl_config.SupportedMultisampleTexStorage = MultisampleTexStorageType::TexStorageOes;
       g_Config.backend_info.bSupportsBitfield = true;
       g_Config.backend_info.bSupportsDynamicSamplerIndexing = g_ogl_config.bSupportsAEP;
     }
@@ -433,6 +436,7 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       g_ogl_config.bSupportsDebug = true;
       g_ogl_config.bSupportsMSAA = true;
       g_ogl_config.bSupportsTextureStorage = true;
+      g_ogl_config.SupportedMultisampleTexStorage = MultisampleTexStorageType::TexStorageCore;
       g_Config.backend_info.bSupportsBitfield = true;
       g_Config.backend_info.bSupportsDynamicSamplerIndexing = true;
       g_Config.backend_info.bSupportsSettingObjectNames = true;
@@ -440,6 +444,9 @@ bool PopulateConfig(GLContext* m_main_gl_context)
   }
   else
   {
+    if (GLExtensions::Supports("GL_ARB_texture_storage_multisample"))
+      g_ogl_config.SupportedMultisampleTexStorage = MultisampleTexStorageType::TexStorageCore;
+
     if (GLExtensions::Version() < 300)
     {
       PanicAlertFmtT("GPU: OGL ERROR: Need at least GLSL 1.30\n"
@@ -486,6 +493,7 @@ bool PopulateConfig(GLContext* m_main_gl_context)
         g_ogl_config.eSupportedGLSLVersion = Glsl430;
       }
       g_ogl_config.bSupportsTextureStorage = true;
+      g_ogl_config.SupportedMultisampleTexStorage = MultisampleTexStorageType::TexStorageCore;
       g_ogl_config.bSupportsImageLoadStore = true;
       g_Config.backend_info.bSupportsSSAA = true;
       g_Config.backend_info.bSupportsSettingObjectNames = true;

--- a/Source/Core/VideoBackends/OGL/OGLConfig.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.cpp
@@ -333,11 +333,6 @@ bool PopulateConfig(GLContext* m_main_gl_context)
   g_ogl_config.bSupportsDebug =
       GLExtensions::Supports("GL_KHR_debug") || GLExtensions::Supports("GL_ARB_debug_output");
   g_ogl_config.bSupportsTextureStorage = GLExtensions::Supports("GL_ARB_texture_storage");
-  g_ogl_config.bSupports3DTextureStorageMultisample =
-      GLExtensions::Supports("GL_ARB_texture_storage_multisample") ||
-      GLExtensions::Supports("GL_OES_texture_storage_multisample_2d_array");
-  g_ogl_config.bSupports2DTextureStorageMultisample =
-      GLExtensions::Supports("GL_ARB_texture_storage_multisample");
   g_ogl_config.bSupportsImageLoadStore = GLExtensions::Supports("GL_ARB_shader_image_load_store");
   g_ogl_config.bSupportsConservativeDepth = GLExtensions::Supports("GL_ARB_conservative_depth");
   g_ogl_config.bSupportsAniso = GLExtensions::Supports("GL_EXT_texture_filter_anisotropic");
@@ -417,16 +412,8 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       g_Config.backend_info.bSupportsFragmentStoresAndAtomics = true;
       g_ogl_config.bSupportsMSAA = true;
       g_ogl_config.bSupportsTextureStorage = true;
-      g_ogl_config.bSupports2DTextureStorageMultisample = true;
       g_Config.backend_info.bSupportsBitfield = true;
       g_Config.backend_info.bSupportsDynamicSamplerIndexing = g_ogl_config.bSupportsAEP;
-      if (g_ActiveConfig.stereo_mode != StereoMode::Off && g_ActiveConfig.iMultisamples > 1 &&
-          !g_ogl_config.bSupports3DTextureStorageMultisample)
-      {
-        // GLES 3.1 can't support stereo rendering and MSAA
-        OSD::AddMessage("MSAA Stereo rendering isn't supported by your GPU.", 10000);
-        Config::SetCurrent(Config::GFX_MSAA, UINT32_C(1));
-      }
     }
     else
     {
@@ -446,8 +433,6 @@ bool PopulateConfig(GLContext* m_main_gl_context)
       g_ogl_config.bSupportsDebug = true;
       g_ogl_config.bSupportsMSAA = true;
       g_ogl_config.bSupportsTextureStorage = true;
-      g_ogl_config.bSupports2DTextureStorageMultisample = true;
-      g_ogl_config.bSupports3DTextureStorageMultisample = true;
       g_Config.backend_info.bSupportsBitfield = true;
       g_Config.backend_info.bSupportsDynamicSamplerIndexing = true;
       g_Config.backend_info.bSupportsSettingObjectNames = true;

--- a/Source/Core/VideoBackends/OGL/OGLConfig.h
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.h
@@ -45,6 +45,13 @@ enum class EsFbFetchType
   FbFetchArm,
 };
 
+enum class MultisampleTexStorageType
+{
+  TexStorageNone,
+  TexStorageCore,
+  TexStorageOes,
+};
+
 // ogl-only config, so not in VideoConfig.h
 struct VideoConfig
 {
@@ -62,6 +69,7 @@ struct VideoConfig
   EsPointSizeType SupportedESPointSize;
   EsTexbufType SupportedESTextureBuffer;
   bool bSupportsTextureStorage;
+  MultisampleTexStorageType SupportedMultisampleTexStorage;
   bool bSupportsConservativeDepth;
   bool bSupportsImageLoadStore;
   bool bSupportsAniso;

--- a/Source/Core/VideoBackends/OGL/OGLConfig.h
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.h
@@ -22,6 +22,14 @@ enum GlslVersion
   GlslEs310,  // GLES 3.1
   GlslEs320,  // GLES 3.2
 };
+
+enum class EsPointSizeType
+{
+  PointSizeNone,
+  PointSizeOes,
+  PointSizeExt,
+};
+
 enum class EsTexbufType
 {
   TexbufNone,
@@ -51,7 +59,7 @@ struct VideoConfig
   bool bSupportsAEP;
   bool bSupportsDebug;
   bool bSupportsCopySubImage;
-  u8 SupportedESPointSize;
+  EsPointSizeType SupportedESPointSize;
   EsTexbufType SupportedESTextureBuffer;
   bool bSupportsTextureStorage;
   bool bSupports2DTextureStorageMultisample;

--- a/Source/Core/VideoBackends/OGL/OGLConfig.h
+++ b/Source/Core/VideoBackends/OGL/OGLConfig.h
@@ -62,8 +62,6 @@ struct VideoConfig
   EsPointSizeType SupportedESPointSize;
   EsTexbufType SupportedESTextureBuffer;
   bool bSupportsTextureStorage;
-  bool bSupports2DTextureStorageMultisample;
-  bool bSupports3DTextureStorageMultisample;
   bool bSupportsConservativeDepth;
   bool bSupportsImageLoadStore;
   bool bSupportsAniso;

--- a/Source/Core/VideoBackends/OGL/OGLTexture.cpp
+++ b/Source/Core/VideoBackends/OGL/OGLTexture.cpp
@@ -130,12 +130,18 @@ OGLTexture::OGLTexture(const TextureConfig& tex_config, std::string_view name)
   GLenum gl_internal_format = GetGLInternalFormatForTextureFormat(m_config.format, true);
   if (tex_config.IsMultisampled())
   {
-    if (g_ogl_config.bSupportsTextureStorage)
+    ASSERT(g_ogl_config.bSupportsMSAA);
+    if (g_ogl_config.SupportedMultisampleTexStorage != MultisampleTexStorageType::TexStorageNone)
+    {
       glTexStorage3DMultisample(target, tex_config.samples, gl_internal_format, m_config.width,
                                 m_config.height, m_config.layers, GL_FALSE);
+    }
     else
+    {
+      ASSERT(!g_ogl_config.bIsES);
       glTexImage3DMultisample(target, tex_config.samples, gl_internal_format, m_config.width,
                               m_config.height, m_config.layers, GL_FALSE);
+    }
   }
   else if (g_ogl_config.bSupportsTextureStorage)
   {

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -722,6 +722,9 @@ void ProgramShaderCache::CreateHeader()
     break;
   }
 
+  // The sampler2DMSArray keyword is reserved in GLSL ES 3.0 and 3.1, but is available in 3.2.
+  const bool use_multisample_2d_array_precision = v >= GlslEs320;
+
   std::string shader_shuffle_string;
   if (g_ogl_config.bSupportsKHRShaderSubgroup)
   {
@@ -849,7 +852,7 @@ void ProgramShaderCache::CreateHeader()
       (is_glsles && g_ActiveConfig.backend_info.bSupportsPaletteConversion) ?
           "precision highp usamplerBuffer;" :
           "",
-      v > GlslEs300 ? "precision highp sampler2DMSArray;" : "",
+      use_multisample_2d_array_precision ? "precision highp sampler2DMSArray;" : "",
       v >= GlslEs310 ? "precision highp image2DArray;" : "");
 }
 

--- a/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
+++ b/Source/Core/VideoBackends/OGL/ProgramShaderCache.cpp
@@ -664,12 +664,13 @@ void ProgramShaderCache::CreateHeader()
   std::string SupportedESTextureBuffer;
   switch (g_ogl_config.SupportedESPointSize)
   {
-  case 1:
+  case EsPointSizeType::PointSizeOes:
     SupportedESPointSize = "#extension GL_OES_geometry_point_size : enable";
     break;
-  case 2:
+  case EsPointSizeType::PointSizeExt:
     SupportedESPointSize = "#extension GL_EXT_geometry_point_size : enable";
     break;
+  case EsPointSizeType::PointSizeNone:
   default:
     SupportedESPointSize = "";
     break;


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/11628