### PR TITLE
InputCommon: Don't treat two analog inputs as a spurious trigger combo

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/MappingCommon.cpp
@@ -138,8 +138,8 @@ void RemoveSpuriousTriggerCombinations(
 {
   const auto is_spurious = [&](auto& detection) {
     return std::any_of(detections->begin(), detections->end(), [&](auto& d) {
-      // This is a suprious digital detection if a "smooth" (analog) detection is temporally near.
-      return &d != &detection && d.smoothness > 1 &&
+      // This is a spurious digital detection if a "smooth" (analog) detection is temporally near.
+      return &d != &detection && d.smoothness > 1 && d.smoothness > detection.smoothness &&
              abs(d.press_time - detection.press_time) < SPURIOUS_TRIGGER_COMBO_THRESHOLD;
     });
   };


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/11897

This doesn´t seem to be related to the Input overhaul, so I assume it´s safe to merge. 