### PR TITLE
Data: Add missing Super Mario Sunshine goop map texture to graphics mod

### DIFF
--- a/Data/Sys/Load/GraphicMods/Super Mario Sunshine/metadata.json
+++ b/Data/Sys/Load/GraphicMods/Super Mario Sunshine/metadata.json
@@ -49,6 +49,10 @@
 				{
 					"type": "efb",
 					"texture_filename": "efb1_n000000_256x256_1"
+				},
+				{
+					"type": "efb",
+					"texture_filename": "efb1_n000000_512x512_1"
 				}
 			]
 		}


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/11905