### PR TITLE
Add HostThreadLock to MMJR2 onHotkeyEvent and getHotkeyState

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -324,12 +324,14 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onGamePadMov
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_onHotkeyEvent(
         JNIEnv* env, jclass, jint HotkeyId, jboolean showMessage)
 {
+  HostThreadLock guard;
   return AndroidHotkey::onHotkeyEvent(HotkeyId, showMessage);
 }
 
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_getHotkeyState(
         JNIEnv* env, jclass, jint HotkeyId)
 {
+  HostThreadLock guard;
   return AndroidHotkey::getHotkeyState(HotkeyId);
 }
 


### PR DESCRIPTION
The onHotkeyEvent and getHotkeyState requires HostThreadLock. This change makes Hotkey buttons work again.