### PR TITLE
Arm64Emitter/x64Emitter: Use nodiscard for FixupBranch

### DIFF
--- a/Source/Core/Common/Arm64Emitter.h
+++ b/Source/Core/Common/Arm64Emitter.h
@@ -644,7 +644,7 @@ private:
   void EncodeAddressInst(u32 op, ARM64Reg Rd, s32 imm);
   void EncodeLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm);
 
-  FixupBranch WriteFixupBranch();
+  [[nodiscard]] FixupBranch WriteFixupBranch();
 
   template <typename T>
   void MOVI2RImpl(ARM64Reg Rd, T imm);
@@ -680,13 +680,13 @@ public:
 
   // FixupBranch branching
   void SetJumpTarget(FixupBranch const& branch);
-  FixupBranch CBZ(ARM64Reg Rt);
-  FixupBranch CBNZ(ARM64Reg Rt);
-  FixupBranch B(CCFlags cond);
-  FixupBranch TBZ(ARM64Reg Rt, u8 bit);
-  FixupBranch TBNZ(ARM64Reg Rt, u8 bit);
-  FixupBranch B();
-  FixupBranch BL();
+  [[nodiscard]] FixupBranch CBZ(ARM64Reg Rt);
+  [[nodiscard]] FixupBranch CBNZ(ARM64Reg Rt);
+  [[nodiscard]] FixupBranch B(CCFlags cond);
+  [[nodiscard]] FixupBranch TBZ(ARM64Reg Rt, u8 bit);
+  [[nodiscard]] FixupBranch TBNZ(ARM64Reg Rt, u8 bit);
+  [[nodiscard]] FixupBranch B();
+  [[nodiscard]] FixupBranch BL();
 
   // Compare and Branch
   void CBZ(ARM64Reg Rt, const void* ptr);

--- a/Source/Core/Common/x64Emitter.h
+++ b/Source/Core/Common/x64Emitter.h
@@ -450,7 +450,7 @@ public:
   void RET();
   void RET_FAST();
   void UD2();
-  FixupBranch J(Jump jump = Jump::Short);
+  [[nodiscard]] FixupBranch J(Jump jump = Jump::Short);
 
   void JMP(const u8* addr, Jump jump = Jump::Short);
   void JMPptr(const OpArg& arg);
@@ -459,10 +459,10 @@ public:
 #undef CALL
 #endif
   void CALL(const void* fnptr);
-  FixupBranch CALL();
+  [[nodiscard]] FixupBranch CALL();
   void CALLptr(OpArg arg);
 
-  FixupBranch J_CC(CCFlags conditionCode, Jump jump = Jump::Short);
+  [[nodiscard]] FixupBranch J_CC(CCFlags conditionCode, Jump jump = Jump::Short);
   void J_CC(CCFlags conditionCode, const u8* addr);
 
   void SetJumpTarget(const FixupBranch& branch);


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/11976

This should prevent future occurrences of the type of problem that was fixed in https://github.com/Medard22/Dolphin-MMJR2-VBI/pull/383