### PR TITLE
Rename "Speed up Disc Transfer Rate" to "Emulate Disc Speed"

### DIFF
--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -354,7 +354,7 @@ Without the correct bios file, the app may crash due to a bug that I can not fix
     <string name="aspect_ratio_description">Select what aspect ratio to use when rendering</string>
     <string name="shader_compilation_mode">Shader Compilation Mode</string>
     <string name="fast_disc_speed">Fast Disc Speed</string>
-    <string name="fast_disc_speed_description">Accelerates the emulated disc speed, reducing loading times. Some games that rely on accurate disc speed emulation could become instable, fail to read data and crash.</string>
+    <string name="fast_disc_speed_description">Accelerates the emulated disc speed, reducing loading times. Some games that rely on accurate disc speed emulation could become unstable, fail to read data and crash.</string>
     <string name="wait_for_shaders">Compile Shaders Before Starting</string>
     <string name="wait_for_shaders_description">This causes a delay when launching games, but will reduce stuttering early on.</string>
 

--- a/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
+++ b/Source/Core/DolphinQt/Config/GameConfigEdit.cpp
@@ -38,8 +38,8 @@ GameConfigEdit::GameConfigEdit(QWidget* parent, QString path, bool read_only)
                                                  "cause issues. Defaults to <b>True</b>"));
 
   AddDescription(QStringLiteral("FastDiscSpeed"),
-                 tr("Shortens loading times but may break some games. Can have negative effects on "
-                    "performance. Defaults to <b>False</b>"));
+                 tr("Emulate the disc speed of real hardware. Disabling can cause instability. "
+                    "Defaults to <b>True</b>"));
 
   AddDescription(QStringLiteral("MMU"), tr("Controls whether or not the Memory Management Unit "
                                            "should be emulated fully. Few games require it."));


### PR DESCRIPTION
I implemented the same inverted checkbox behavior as Dolphin Official, but I couldn’t bring myself to merge it. I feel it somewhat goes against the spirit of MMJR2. The description message includes a reasonable warning, and "Emulate Disc Speed" is imho a pretty bad name. "Accurate Disc Speed" would probably be better, but I don’t want to confuse people by coming up with additional names. In this PR  I will merge only the Qt part of the original commit and fix a typo in the description. The Android UI will be left untouched for now.

+ https://github.com/dolphin-emu/dolphin/pull/11538