### PR TITLE
GCC: Suppress PPCSTATE_OFF invalid-offsetof warnings

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64Common/Jit64PowerPCState.h
+++ b/Source/Core/Core/PowerPC/Jit64Common/Jit64PowerPCState.h
@@ -11,11 +11,26 @@
 
 // We offset by 0x80 because the range of one byte memory offsets is
 // -0x80..0x7f.
+#ifdef __GNUC__
+#define PPCSTATE_OFF(i)                                                                            \
+  ([]() consteval {                                                                                \
+    _Pragma("GCC diagnostic push")                                                                 \
+            _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"") return static_cast<int>(      \
+                offsetof(PowerPC::PowerPCState, i)) -                                              \
+        0x80;                                                                                      \
+    _Pragma("GCC diagnostic pop")                                                                  \
+  }())
+
+#define PPCSTATE_OFF_ARRAY(elem, i)                                                                \
+  (PPCSTATE_OFF(elem[0]) + static_cast<int>(sizeof(PowerPC::PowerPCState::elem[0]) * (i)))
+#else
 #define PPCSTATE_OFF(i) (static_cast<int>(offsetof(PowerPC::PowerPCState, i)) - 0x80)
+
 #define PPCSTATE_OFF_ARRAY(elem, i)                                                                \
   (static_cast<int>(offsetof(PowerPC::PowerPCState, elem[0]) +                                     \
                     sizeof(PowerPC::PowerPCState::elem[0]) * (i)) -                                \
    0x80)
+#endif
 
 #define PPCSTATE_OFF_GPR(i) PPCSTATE_OFF_ARRAY(gpr, i)
 #define PPCSTATE_OFF_CR(i) PPCSTATE_OFF_ARRAY(cr.fields, i)

--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
@@ -25,10 +25,23 @@ constexpr Arm64Gen::ARM64Reg PPC_REG = Arm64Gen::ARM64Reg::X29;
 // PC register when calling the dispatcher
 constexpr Arm64Gen::ARM64Reg DISPATCHER_PC = Arm64Gen::ARM64Reg::W26;
 
+#ifdef __GNUC__
+#define PPCSTATE_OFF(elem)                                                                         \
+  ([]() consteval {                                                                                \
+    _Pragma("GCC diagnostic push")                                                                 \
+        _Pragma("GCC diagnostic ignored \"-Winvalid-offsetof\"") return offsetof(                  \
+            PowerPC::PowerPCState, elem);                                                          \
+    _Pragma("GCC diagnostic pop")                                                                  \
+  }())
+
+#define PPCSTATE_OFF_ARRAY(elem, i)                                                                \
+  (PPCSTATE_OFF(elem[0]) + sizeof(PowerPC::PowerPCState::elem[0]) * (i))
+#else
 #define PPCSTATE_OFF(elem) (offsetof(PowerPC::PowerPCState, elem))
 
 #define PPCSTATE_OFF_ARRAY(elem, i)                                                                \
   (offsetof(PowerPC::PowerPCState, elem[0]) + sizeof(PowerPC::PowerPCState::elem[0]) * (i))
+#endif
 
 #define PPCSTATE_OFF_GPR(i) PPCSTATE_OFF_ARRAY(gpr, i)
 #define PPCSTATE_OFF_CR(i) PPCSTATE_OFF_ARRAY(cr.fields, i)


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/12128