### PR TITLE
Android: Remove HostThreadLocks that are no longer needed

### DIFF
--- a/Source/Android/jni/Config/NativeConfig.cpp
+++ b/Source/Android/jni/Config/NativeConfig.cpp
@@ -119,7 +119,6 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_loadGameInis
                                                                                  jstring jGameId,
                                                                                  jint jRevision)
 {
-  HostThreadLock guard;
   const std::string game_id = GetJString(env, jGameId);
   const u16 revision = static_cast<u16>(jRevision);
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
@@ -129,7 +128,6 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_loadGameInis
 JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_unloadGameInis(JNIEnv*, jclass)
 {
-  HostThreadLock guard;
   Config::RemoveLayer(Config::LayerType::GlobalGame);
   Config::RemoveLayer(Config::LayerType::LocalGame);
 }
@@ -137,7 +135,10 @@ Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_unloadGameIn
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_save(
     JNIEnv*, jclass, jint layer)
 {
+  // HostThreadLock is used to ensure we don't try to save to SYSCONF at the same time as
+  // emulation shutdown does
   HostThreadLock guard;
+
   const std::shared_ptr<Config::Layer> layer_ptr = GetLayer(layer, {});
 
   // Workaround for the Settings class carrying around a legacy map of settings it always saves
@@ -159,7 +160,6 @@ JNIEXPORT jboolean JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_deleteKey(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key)
 {
-  HostThreadLock guard;
   const Config::Location location = GetLocation(env, file, section, key);
   const bool had_value = GetLayer(layer, location)->DeleteKey(location);
   if (had_value)
@@ -203,7 +203,6 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setString(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jstring value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), GetJString(env, value));
 }
 
@@ -211,21 +210,18 @@ JNIEXPORT void JNICALL
 Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setBoolean(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jboolean value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), static_cast<bool>(value));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setInt(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jint value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), value);
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_features_settings_model_NativeConfig_setFloat(
     JNIEnv* env, jclass, jint layer, jstring file, jstring section, jstring key, jfloat value)
 {
-  HostThreadLock guard;
   return Set(layer, GetLocation(env, file, section, key), value);
 }
 }

--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -611,18 +611,12 @@ JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_Initialize(J
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_ReportStartToAnalytics(JNIEnv*,
                                                                                            jclass)
 {
-  // Identity generation ends up calling config code, and some config callbacks use RunAsCPUThread
-  HostThreadLock guard;
-
   DolphinAnalytics::Instance().ReportDolphinStart(GetAnalyticValue("DEVICE_TYPE"));
 }
 
 JNIEXPORT void JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_GenerateNewStatisticsId(JNIEnv*,
                                                                                             jclass)
 {
-  // Identity generation ends up calling config code, and some config callbacks use RunAsCPUThread
-  HostThreadLock guard;
-  
   DolphinAnalytics::Instance().GenerateNewIdentity();
 }
 


### PR DESCRIPTION
Based on 
+ https://github.com/dolphin-emu/dolphin/pull/12316

with some small changes due to difference in MMJR2 codebase. 