### PR TITLE
Android: Expose color space settings - Part 1

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/BooleanSetting.java
@@ -233,6 +233,10 @@ public enum BooleanSetting implements AbstractBooleanSetting
           "DisableCopyFilter", false),
   GFX_ENHANCE_ARBITRARY_MIPMAP_DETECTION(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
           "ArbitraryMipmapDetection", false),
+  GFX_CC_CORRECT_COLOR_SPACE(Settings.FILE_GFX, Settings.SECTION_GFX_COLOR_CORRECTION,
+          "CorrectColorSpace", false),
+  GFX_CC_CORRECT_GAMMA(Settings.FILE_GFX, Settings.SECTION_GFX_COLOR_CORRECTION,
+          "CorrectGamma", false),
 
   GFX_STEREO_SWAP_EYES(Settings.FILE_GFX, Settings.SECTION_STEREOSCOPY, "StereoSwapEyes", false),
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/FloatSetting.java
@@ -7,7 +7,8 @@ public enum FloatSetting implements AbstractFloatSetting
   // These entries have the same names and order as in C++, just for consistency.
   GFX_DISPLAY_SCALE(Settings.FILE_GFX, Settings.SECTION_GFX_SETTINGS,"DisplayScale", 1.0f),
   MAIN_EMULATION_SPEED(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "EmulationSpeed", 1.0f),
-  MAIN_OVERCLOCK(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "Overclock", 0.6f);
+  MAIN_OVERCLOCK(Settings.FILE_DOLPHIN, Settings.SECTION_INI_CORE, "Overclock", 1.0f),
+  GFX_CC_GAME_GAMMA(Settings.FILE_GFX, Settings.SECTION_GFX_COLOR_CORRECTION, "GameGamma", 2.35f);
 
   private final String mFile;
   private final String mSection;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/IntSetting.java
@@ -60,8 +60,10 @@ public enum IntSetting implements AbstractIntSetting
   GFX_ENHANCE_FORCE_TEXTURE_FILTERING(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
           "ForceTextureFiltering", 0),
 
-  GFX_ENHANCE_MAX_ANISOTROPY(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS, "MaxAnisotropy",
-          0),
+  GFX_ENHANCE_MAX_ANISOTROPY(Settings.FILE_GFX, Settings.SECTION_GFX_ENHANCEMENTS,
+          "MaxAnisotropy", 0),
+  GFX_CC_GAME_COLOR_SPACE(Settings.FILE_GFX, Settings.SECTION_GFX_COLOR_CORRECTION,
+          "GameColorSpace", 0),
 
   GFX_STEREO_MODE(Settings.FILE_GFX, Settings.SECTION_STEREOSCOPY, "StereoMode", 0),
   GFX_STEREO_DEPTH(Settings.FILE_GFX, Settings.SECTION_STEREOSCOPY, "StereoDepth", 0),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/Settings.java
@@ -38,6 +38,7 @@ public class Settings implements Closeable
   public static final String SECTION_LOGGER_OPTIONS = "Options";
 
   public static final String SECTION_GFX_SETTINGS = "Settings";
+  public static final String SECTION_GFX_COLOR_CORRECTION = "ColorCorrection";
   public static final String SECTION_GFX_ENHANCEMENTS = "Enhancements";
   public static final String SECTION_GFX_HACKS = "Hacks";
 

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/MenuTag.java
@@ -19,6 +19,7 @@ public enum MenuTag
   CONFIG_LOG("config_log"),
   DEBUG("debug"),
   GRAPHICS("graphics"),
+  COLOR_CORRECTION("color_correction"),
   ENHANCEMENTS("enhancements"),
   CUSTOM_TEXTURES("custom_textures"),
   STEREOSCOPY("stereoscopy"),

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragment.java
@@ -49,7 +49,8 @@ public final class SettingsFragment extends Fragment implements SettingsFragment
     titles.put(MenuTag.CONFIG_WII, R.string.wii_submenu);
     titles.put(MenuTag.CONFIG_ADVANCED, R.string.advanced_submenu);
     titles.put(MenuTag.DEBUG, R.string.debug_submenu);
-	titles.put(MenuTag.GRAPHICS, R.string.graphics_settings);
+    titles.put(MenuTag.GRAPHICS, R.string.graphics_settings);
+    titles.put(MenuTag.COLOR_CORRECTION, R.string.color_correction_submenu);
     titles.put(MenuTag.ENHANCEMENTS, R.string.enhancements_submenu);
     titles.put(MenuTag.STEREOSCOPY, R.string.stereoscopy_submenu);
     titles.put(MenuTag.HACKS, R.string.hacks_submenu);

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsFragmentPresenter.java
@@ -196,6 +196,10 @@ public final class SettingsFragmentPresenter
         addWiimoteSettings(sl);
         break;
 
+      case COLOR_CORRECTION:
+        addColorCorrectionSettings(sl);
+        break;
+      
       case ENHANCEMENTS:
         addEnhanceSettings(sl);
         break;
@@ -670,8 +674,7 @@ public final class SettingsFragmentPresenter
             R.string.show_graphs_description));
     sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SHOW_SPEED, R.string.show_speed,
             R.string.show_speed_description));
-    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SHOW_SPEED_COLORS,
-            R.string.show_speed_colors,
+    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_SHOW_SPEED_COLORS, R.string.show_speed_colors,
             R.string.show_speed_colors_description));
     sl.add(new SingleChoiceSettingDynamicDescriptions(mContext,
             IntSetting.GFX_SHADER_COMPILATION_MODE, R.string.shader_compilation_mode, 0,
@@ -685,10 +688,19 @@ public final class SettingsFragmentPresenter
     sl.add(new PercentSliderSetting(mContext, FloatSetting.GFX_DISPLAY_SCALE, R.string.setting_display_scale,
             0, 0, 200, "%"));
 
+    sl.add(new SubmenuSetting(mContext, R.string.color_correction_submenu, MenuTag.COLOR_CORRECTION));
     sl.add(new SubmenuSetting(mContext, R.string.enhancements_submenu, MenuTag.ENHANCEMENTS));
     sl.add(new SubmenuSetting(mContext, R.string.hacks_submenu, MenuTag.HACKS));
     sl.add(new SubmenuSetting(mContext, R.string.advanced_graphics_submenu,
             MenuTag.ADVANCED_GRAPHICS));
+  }
+
+  private void addColorCorrectionSettings(ArrayList<SettingsItem> sl)
+  {
+    sl.add(new CheckBoxSetting(mContext, BooleanSetting.GFX_CC_CORRECT_COLOR_SPACE,
+            R.string.correct_color_space, R.string.correct_color_space_description));
+    sl.add(new SingleChoiceSetting(mContext, IntSetting.GFX_CC_GAME_COLOR_SPACE, R.string.game_color_space, 0,
+            R.array.colorSpaceEntries, R.array.colorSpaceValues));
   }
 
   private void addEnhanceSettings(ArrayList<SettingsItem> sl)

--- a/Source/Android/app/src/main/res/values/arrays.xml
+++ b/Source/Android/app/src/main/res/values/arrays.xml
@@ -673,6 +673,17 @@
         <item>22</item>
     </integer-array>
 
+    <string-array name="colorSpaceEntries">
+        <item>@string/ntscm_space</item>
+        <item>@string/ntscj_space</item>
+        <item>@string/pal_space</item>
+    </string-array>
+    <integer-array name="colorSpaceValues">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+
     <!-- Application Theme -->
     <string-array name="themeEntries">
         <item>MMJR2 Purple</item>

--- a/Source/Android/app/src/main/res/values/strings.xml
+++ b/Source/Android/app/src/main/res/values/strings.xml
@@ -301,6 +301,14 @@ Without the correct bios file, the app may crash due to a bug that I can not fix
     <string name="disable_copy_filter_description">Disables the blending of adjacent rows when copying the EFB. This is known in some games as \"deflickering\" or \"smoothing\". Disabling the filter is usually safe, and may result in a sharper image.</string>
     <string name="arbitrary_mipmap_detection">Arbitrary Mipmap Detection</string>
     <string name="arbitrary_mipmap_detection_description">Enables detection of arbitrary mipmaps, which some games use for special distance-based effects.\nMay have false positives that result in blurry textures at increased internal resolution, such as in games that use very low resolution mipmaps. Disabling this can also reduce stutter in games that frequently load new textures.\n\nIf unsure, leave this unchecked.</string>
+    <string name="color_correction_submenu">Color Correction</string>
+    <string name="color_space">Color Space</string>
+    <string name="correct_color_space">Correct Color Space</string>
+    <string name="correct_color_space_description">Converts the colors from the color spaces that GC/Wii were meant to work with to sRGB/Rec.709.</string>
+    <string name="game_color_space">Game Color Space</string>
+    <string name="ntscm_space">NTSC-M (SMPTE 170M)</string>
+    <string name="ntscj_space">NTSC-J (ARUB TR-89)</string>
+    <string name="pal_space">PAL (EBU)</string>
     <string name="stereoscopy_submenu">Stereoscopy</string>
     <string name="stereoscopy_submenu_description">Stereoscopy allows you to get a better feeling of depth if you have the necessary hardware.\nHeavily decreases emulation speed and sometimes causes issues</string>
     <string name="wide_screen_hack">Widescreen Hack</string>


### PR DESCRIPTION
Based on 
+ https://github.com/dolphin-emu/dolphin/pull/12095

This PR exposes color space correction in the Android UI. I had to split the color space settings into two parts. This one was fairly straightforward to implement. The second part involves exposing settings for gamma values. The emulator core expects values between 2.2 and 2.8, but the MMJR2 UI currently doesn't have a way to pass float values to the core. Unfortunately, my understanding of Android code is too limited to implement this on my own for now.