### PR TITLE
PageFaultTest: Use GTEST_SKIP instead of early return

### DIFF
--- a/Source/UnitTests/Core/PageFaultTest.cpp
+++ b/Source/UnitTests/Core/PageFaultTest.cpp
@@ -68,10 +68,8 @@ static void ASAN_DISABLE perform_invalid_access(void* data)
 TEST(PageFault, PageFault)
 {
   if (!EMM::IsExceptionHandlerSupported())
-  {
-    // TODO: Use GTEST_SKIP() instead when GTest is updated to 1.10+
-    return;
-  }
+    GTEST_SKIP() << "Skipping PageFault test because exception handler is unsupported.";
+
   EMM::InstallExceptionHandler();
   void* data = Common::AllocateMemoryPages(PAGE_GRAN);
   EXPECT_NE(data, nullptr);


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/12147