### PR TITLE
SaveStates : Fix MainWindow.m_state_slot is not restored from Qt.ini Emulation/StateSlot. 

### DIFF
--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -279,6 +279,9 @@ MainWindow::MainWindow(std::unique_ptr<BootParameters> boot_parameters,
     }
   }
 
+  m_state_slot =
+      std::clamp(Settings::Instance().GetStateSlot(), 1, static_cast<int>(State::NUM_STATES));
+
   QSettings& settings = Settings::GetQSettings();
 
   restoreState(settings.value(QStringLiteral("mainwindow/state")).toByteArray());


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/12201