### PR TITLE
AchievementManager: Don't store pointer to rc_runtime_event_t in lambda.

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -20,9 +20,9 @@ const Info<int> GFX_ADAPTER{{System::GFX, "Hardware", "Adapter"}, 0};
 // Graphics.Settings
 
 const Info<bool> GFX_WIDESCREEN_HACK{{System::GFX, "Settings", "wideScreenHack"}, false};
-const Info<AspectMode> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"}, AspectMode::Stretch};
+const Info<AspectMode> GFX_ASPECT_RATIO{{System::GFX, "Settings", "AspectRatio"}, AspectMode::Auto};
 const Info<AspectMode> GFX_SUGGESTED_ASPECT_RATIO{{System::GFX, "Settings", "SuggestedAspectRatio"},
-                                                  AspectMode::Stretch};
+                                                  AspectMode::Auto};
 const Info<float> GFX_DISPLAY_SCALE{{System::GFX, "Settings", "DisplayScale"}, 1.0f};
 const Info<u32> GFX_WIDESCREEN_HEURISTIC_TRANSITION_THRESHOLD{
     {System::GFX, "Settings", "WidescreenHeuristicTransitionThreshold"}, 3};


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/12228

What is wrong with me. I managed to merge an unrelated commit again. Commit [43debec](https://github.com/Medard22/Dolphin-MMJR2-VBI/pull/571/commits/43debece6dd0ec236472693ef05660f6d2e5a58b) changes the default aspect ratio for Android from Stretch to Auto.