### PR TITLE
JIT64: for twx instruction, raise exception with correct SRR0

### DIFF
--- a/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/Jit_Integer.cpp
@@ -2752,6 +2752,7 @@ void Jit64::twX(UGeckoInstruction inst)
     gpr.Flush();
     fpr.Flush();
 
+    MOV(32, PPCSTATE(pc), Imm32(js.compilerPC));
     WriteExceptionExit();
 
     SwitchToNearCode();


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/12257