### PR TITLE
New versioning system

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -146,7 +146,7 @@ dependencies {
 
 static def getVersion()
 {
-    return '2.4.000-dev'
+    return 'DEV-23.10.11'
 }
 
 def getBuildVersionCode() {


### PR DESCRIPTION
The old versioning system was partly inherited from MMJR2 and always felt somewhat arbitrary. The new system reflects the codebase of the official Dolphin project that MMJR2-VBI is based on.

For internal development builds, I will use the date of the latest available MMJR2-VBI release: DEV-RR.MM.DD.

For release and beta builds, I will use the date and upstream version to mark the codebase it is built upon - URR.MM.DD-version. For example, for codebase based on Dolphin 5.0-20594 from December 10th, 2023, the version would be U23.12.10-20594. 