### PR TITLE
Android: build updates

### DIFF
--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -8,14 +8,13 @@ def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
-    defaultConfig {
-        // compileSdkVersion 33
-        compileSdk 33
+        compileSdk 34
+        ndkVersion "26.1.10909125"
+
+    buildFeatures {
+        viewBinding true
+        buildConfig true
     }
-
-    ndkVersion "26.1.10909125"
-
-    viewBinding.enabled = true
 
     compileOptions {
         // Flag to enable support for the new language APIs
@@ -144,9 +143,16 @@ dependencies {
     implementation 'com.nononsenseapps:filepicker:4.2.1'
 }
 
-static def getVersion()
-{
-    return 'DEV-24.12.19'
+def getVersion() {
+    def versionNumber = '0.0'
+
+    try {
+        versionNumber = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
+    } catch (Exception e) {
+        logger.error('Cannot find git, defaulting to dummy version number')
+    }
+
+    return versionNumber + "-DEV"
 }
 
 def getBuildVersionCode() {

--- a/Source/Android/app/build.gradle
+++ b/Source/Android/app/build.gradle
@@ -98,8 +98,6 @@ android {
 
                 abiFilters "arm64-v8a" //, "x86_64", "armeabi-v7a", "x86"
 
-                abiFilters "arm64-v8a", "x86_64" //, "armeabi-v7a", "x86"
-
                 // Remove the line below if you want to build the C++ unit tests
                 targets "main"
 

--- a/Source/Android/build.gradle
+++ b/Source/Android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
-    id 'com.android.library' version '8.0.2' apply false
+    id 'com.android.application' version '8.2.0' apply false
+    id 'com.android.library' version '8.2.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
 }

--- a/Source/Android/gradle.properties
+++ b/Source/Android/gradle.properties
@@ -14,6 +14,5 @@ android.enableJetifier=true
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/Source/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Source/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Nov 28 14:16:47 CET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update compile SDK to 34
- Update AGP to 8.2.0
- FIx gradle deprecation
- Remove duplicate abiFilters 
- Remove x86_64 build variant
- Clean up build.gradle
- Use short commit hash + "-DEV" as a build version for development test builds