### PR TITLE
VertexLoader: Remove "too many initializer values" workaround functions

### DIFF
--- a/Source/Core/VideoCommon/VertexLoader_Color.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Color.cpp
@@ -181,33 +181,18 @@ void Color_ReadDirect_32b_8888(VertexLoader* loader)
   SetCol(loader, DataReadU32Unswapped());
 }
 
-using Common::EnumMap;
+using Row = Common::EnumMap<TPipelineFunction, ColorFormat::RGBA8888>;
+using Table = Common::EnumMap<Row, VertexComponentFormat::Index16>;
 
-// These functions are to work around a "too many initializer values" error with nested brackets
-// C++ does not let you write std::array<std::array<u32, 2>, 2> a = {{1, 2}, {3, 4}}
-// (although it does allow std::array<std::array<u32, 2>, 2> b = {1, 2, 3, 4})
-constexpr EnumMap<TPipelineFunction, ColorFormat::RGBA8888>
-f(EnumMap<TPipelineFunction, ColorFormat::RGBA8888> in)
-{
-  return in;
-}
-constexpr EnumMap<u32, ColorFormat::RGBA8888> g(EnumMap<u32, ColorFormat::RGBA8888> in)
-{
-  return in;
-}
-
-template <typename T>
-using Table = EnumMap<EnumMap<T, ColorFormat::RGBA8888>, VertexComponentFormat::Index16>;
-
-constexpr Table<TPipelineFunction> s_table_read_color = {
-    f({nullptr, nullptr, nullptr, nullptr, nullptr, nullptr}),
-    f({Color_ReadDirect_16b_565, Color_ReadDirect_24b_888, Color_ReadDirect_32b_888x,
-       Color_ReadDirect_16b_4444, Color_ReadDirect_24b_6666, Color_ReadDirect_32b_8888}),
-    f({Color_ReadIndex_16b_565<u8>, Color_ReadIndex_24b_888<u8>, Color_ReadIndex_32b_888x<u8>,
-       Color_ReadIndex_16b_4444<u8>, Color_ReadIndex_24b_6666<u8>, Color_ReadIndex_32b_8888<u8>}),
-    f({Color_ReadIndex_16b_565<u16>, Color_ReadIndex_24b_888<u16>, Color_ReadIndex_32b_888x<u16>,
-       Color_ReadIndex_16b_4444<u16>, Color_ReadIndex_24b_6666<u16>,
-       Color_ReadIndex_32b_8888<u16>}),
+constexpr Table s_table_read_color = {
+    Row(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr),
+    Row(Color_ReadDirect_16b_565, Color_ReadDirect_24b_888, Color_ReadDirect_32b_888x,
+        Color_ReadDirect_16b_4444, Color_ReadDirect_24b_6666, Color_ReadDirect_32b_8888),
+    Row(Color_ReadIndex_16b_565<u8>, Color_ReadIndex_24b_888<u8>, Color_ReadIndex_32b_888x<u8>,
+        Color_ReadIndex_16b_4444<u8>, Color_ReadIndex_24b_6666<u8>, Color_ReadIndex_32b_8888<u8>),
+    Row(Color_ReadIndex_16b_565<u16>, Color_ReadIndex_24b_888<u16>, Color_ReadIndex_32b_888x<u16>,
+        Color_ReadIndex_16b_4444<u16>, Color_ReadIndex_24b_6666<u16>,
+        Color_ReadIndex_32b_8888<u16>),
 };
 
 }  // Anonymous namespace

--- a/Source/Core/VideoCommon/VertexLoader_Position.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_Position.cpp
@@ -70,65 +70,38 @@ void Pos_ReadIndex(VertexLoader* loader)
   LOG_VTX();
 }
 
-using Common::EnumMap;
+using ComponentCountRow = Common::EnumMap<TPipelineFunction, CoordComponentCount::XYZ>;
+using ComponentFormatTable = Common::EnumMap<ComponentCountRow, ComponentFormat::Float>;
+using Table = Common::EnumMap<ComponentFormatTable, VertexComponentFormat::Index16>;
 
-// These functions are to work around a "too many initializer values" error with nested brackets
-// C++ does not let you write std::array<std::array<u32, 2>, 2> a = {{1, 2}, {3, 4}}
-// (although it does allow std::array<std::array<u32, 2>, 2> b = {1, 2, 3, 4})
-constexpr EnumMap<TPipelineFunction, CoordComponentCount::XYZ> e(TPipelineFunction xy,
-                                                                 TPipelineFunction xyz)
-{
-  return {xy, xyz};
-}
-constexpr EnumMap<u32, CoordComponentCount::XYZ> e(u32 xy, u32 xyz)
-{
-  return {xy, xyz};
-}
-
-constexpr EnumMap<EnumMap<TPipelineFunction, CoordComponentCount::XYZ>, ComponentFormat::Float>
-f(EnumMap<EnumMap<TPipelineFunction, CoordComponentCount::XYZ>, ComponentFormat::Float> in)
-{
-  return in;
-}
-
-constexpr EnumMap<EnumMap<u32, CoordComponentCount::XYZ>, ComponentFormat::Float>
-g(EnumMap<EnumMap<u32, CoordComponentCount::XYZ>, ComponentFormat::Float> in)
-{
-  return in;
-}
-
-template <typename T>
-using Table = EnumMap<EnumMap<EnumMap<T, CoordComponentCount::XYZ>, ComponentFormat::Float>,
-                      VertexComponentFormat::Index16>;
-
-constexpr Table<TPipelineFunction> s_table_read_position = {
-    f({
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
+constexpr Table s_table_read_position = {
+    ComponentFormatTable({
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
     }),
-    f({
-        e(Pos_ReadDirect<u8, 2>, Pos_ReadDirect<u8, 3>),
-        e(Pos_ReadDirect<s8, 2>, Pos_ReadDirect<s8, 3>),
-        e(Pos_ReadDirect<u16, 2>, Pos_ReadDirect<u16, 3>),
-        e(Pos_ReadDirect<s16, 2>, Pos_ReadDirect<s16, 3>),
-        e(Pos_ReadDirect<float, 2>, Pos_ReadDirect<float, 3>),
+    ComponentFormatTable({
+        ComponentCountRow(Pos_ReadDirect<u8, 2>, Pos_ReadDirect<u8, 3>),
+        ComponentCountRow(Pos_ReadDirect<s8, 2>, Pos_ReadDirect<s8, 3>),
+        ComponentCountRow(Pos_ReadDirect<u16, 2>, Pos_ReadDirect<u16, 3>),
+        ComponentCountRow(Pos_ReadDirect<s16, 2>, Pos_ReadDirect<s16, 3>),
+        ComponentCountRow(Pos_ReadDirect<float, 2>, Pos_ReadDirect<float, 3>),
     }),
-    f({
-        e(Pos_ReadIndex<u8, u8, 2>, Pos_ReadIndex<u8, u8, 3>),
-        e(Pos_ReadIndex<u8, s8, 2>, Pos_ReadIndex<u8, s8, 3>),
-        e(Pos_ReadIndex<u8, u16, 2>, Pos_ReadIndex<u8, u16, 3>),
-        e(Pos_ReadIndex<u8, s16, 2>, Pos_ReadIndex<u8, s16, 3>),
-        e(Pos_ReadIndex<u8, float, 2>, Pos_ReadIndex<u8, float, 3>),
+    ComponentFormatTable({
+        ComponentCountRow(Pos_ReadIndex<u8, u8, 2>, Pos_ReadIndex<u8, u8, 3>),
+        ComponentCountRow(Pos_ReadIndex<u8, s8, 2>, Pos_ReadIndex<u8, s8, 3>),
+        ComponentCountRow(Pos_ReadIndex<u8, u16, 2>, Pos_ReadIndex<u8, u16, 3>),
+        ComponentCountRow(Pos_ReadIndex<u8, s16, 2>, Pos_ReadIndex<u8, s16, 3>),
+        ComponentCountRow(Pos_ReadIndex<u8, float, 2>, Pos_ReadIndex<u8, float, 3>),
     }),
-    f({
-        e(Pos_ReadIndex<u16, u8, 2>, Pos_ReadIndex<u16, u8, 3>),
-        e(Pos_ReadIndex<u16, s8, 2>, Pos_ReadIndex<u16, s8, 3>),
-        e(Pos_ReadIndex<u16, u16, 2>, Pos_ReadIndex<u16, u16, 3>),
-        e(Pos_ReadIndex<u16, s16, 2>, Pos_ReadIndex<u16, s16, 3>),
-        e(Pos_ReadIndex<u16, float, 2>, Pos_ReadIndex<u16, float, 3>),
+    ComponentFormatTable({
+        ComponentCountRow(Pos_ReadIndex<u16, u8, 2>, Pos_ReadIndex<u16, u8, 3>),
+        ComponentCountRow(Pos_ReadIndex<u16, s8, 2>, Pos_ReadIndex<u16, s8, 3>),
+        ComponentCountRow(Pos_ReadIndex<u16, u16, 2>, Pos_ReadIndex<u16, u16, 3>),
+        ComponentCountRow(Pos_ReadIndex<u16, s16, 2>, Pos_ReadIndex<u16, s16, 3>),
+        ComponentCountRow(Pos_ReadIndex<u16, float, 2>, Pos_ReadIndex<u16, float, 3>),
     }),
 };
 }  // Anonymous namespace

--- a/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
+++ b/Source/Core/VideoCommon/VertexLoader_TextCoord.cpp
@@ -59,64 +59,38 @@ void TexCoord_ReadIndex(VertexLoader* loader)
   ++loader->m_tcIndex;
 }
 
-using Common::EnumMap;
-// These functions are to work around a "too many initializer values" error with nested brackets
-// C++ does not let you write std::array<std::array<u32, 2>, 2> a = {{1, 2}, {3, 4}}
-// (although it does allow std::array<std::array<u32, 2>, 2> b = {1, 2, 3, 4})
-constexpr EnumMap<TPipelineFunction, TexComponentCount::ST> e(TPipelineFunction s,
-                                                              TPipelineFunction st)
-{
-  return {s, st};
-}
-constexpr EnumMap<u32, TexComponentCount::ST> e(u32 s, u32 st)
-{
-  return {s, st};
-}
+using ComponentCountRow = Common::EnumMap<TPipelineFunction, TexComponentCount::ST>;
+using ComponentFormatTable = Common::EnumMap<ComponentCountRow, ComponentFormat::Float>;
+using Table = Common::EnumMap<ComponentFormatTable, VertexComponentFormat::Index16>;
 
-constexpr EnumMap<EnumMap<TPipelineFunction, TexComponentCount::ST>, ComponentFormat::Float>
-f(EnumMap<EnumMap<TPipelineFunction, TexComponentCount::ST>, ComponentFormat::Float> in)
-{
-  return in;
-}
-
-constexpr EnumMap<EnumMap<u32, TexComponentCount::ST>, ComponentFormat::Float>
-g(EnumMap<EnumMap<u32, TexComponentCount::ST>, ComponentFormat::Float> in)
-{
-  return in;
-}
-
-template <typename T>
-using Table = EnumMap<EnumMap<EnumMap<T, TexComponentCount::ST>, ComponentFormat::Float>,
-                      VertexComponentFormat::Index16>;
-
-constexpr Table<TPipelineFunction> s_table_read_tex_coord = {
-    f({
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
-        e(nullptr, nullptr),
+constexpr Table s_table_read_tex_coord = {
+    ComponentFormatTable({
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
+        ComponentCountRow(nullptr, nullptr),
     }),
-    f({
-        e(TexCoord_ReadDirect<u8, 1>, TexCoord_ReadDirect<u8, 2>),
-        e(TexCoord_ReadDirect<s8, 1>, TexCoord_ReadDirect<s8, 2>),
-        e(TexCoord_ReadDirect<u16, 1>, TexCoord_ReadDirect<u16, 2>),
-        e(TexCoord_ReadDirect<s16, 1>, TexCoord_ReadDirect<s16, 2>),
-        e(TexCoord_ReadDirect<float, 1>, TexCoord_ReadDirect<float, 2>),
+    ComponentFormatTable({
+        ComponentCountRow(TexCoord_ReadDirect<u8, 1>, TexCoord_ReadDirect<u8, 2>),
+        ComponentCountRow(TexCoord_ReadDirect<s8, 1>, TexCoord_ReadDirect<s8, 2>),
+        ComponentCountRow(TexCoord_ReadDirect<u16, 1>, TexCoord_ReadDirect<u16, 2>),
+        ComponentCountRow(TexCoord_ReadDirect<s16, 1>, TexCoord_ReadDirect<s16, 2>),
+        ComponentCountRow(TexCoord_ReadDirect<float, 1>, TexCoord_ReadDirect<float, 2>),
     }),
-    f({
-        e(TexCoord_ReadIndex<u8, u8, 1>, TexCoord_ReadIndex<u8, u8, 2>),
-        e(TexCoord_ReadIndex<u8, s8, 1>, TexCoord_ReadIndex<u8, s8, 2>),
-        e(TexCoord_ReadIndex<u8, u16, 1>, TexCoord_ReadIndex<u8, u16, 2>),
-        e(TexCoord_ReadIndex<u8, s16, 1>, TexCoord_ReadIndex<u8, s16, 2>),
-        e(TexCoord_ReadIndex<u8, float, 1>, TexCoord_ReadIndex<u8, float, 2>),
+    ComponentFormatTable({
+        ComponentCountRow(TexCoord_ReadIndex<u8, u8, 1>, TexCoord_ReadIndex<u8, u8, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u8, s8, 1>, TexCoord_ReadIndex<u8, s8, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u8, u16, 1>, TexCoord_ReadIndex<u8, u16, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u8, s16, 1>, TexCoord_ReadIndex<u8, s16, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u8, float, 1>, TexCoord_ReadIndex<u8, float, 2>),
     }),
-    f({
-        e(TexCoord_ReadIndex<u16, u8, 1>, TexCoord_ReadIndex<u16, u8, 2>),
-        e(TexCoord_ReadIndex<u16, s8, 1>, TexCoord_ReadIndex<u16, s8, 2>),
-        e(TexCoord_ReadIndex<u16, u16, 1>, TexCoord_ReadIndex<u16, u16, 2>),
-        e(TexCoord_ReadIndex<u16, s16, 1>, TexCoord_ReadIndex<u16, s16, 2>),
-        e(TexCoord_ReadIndex<u16, float, 1>, TexCoord_ReadIndex<u16, float, 2>),
+    ComponentFormatTable({
+        ComponentCountRow(TexCoord_ReadIndex<u16, u8, 1>, TexCoord_ReadIndex<u16, u8, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u16, s8, 1>, TexCoord_ReadIndex<u16, s8, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u16, u16, 1>, TexCoord_ReadIndex<u16, u16, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u16, s16, 1>, TexCoord_ReadIndex<u16, s16, 2>),
+        ComponentCountRow(TexCoord_ReadIndex<u16, float, 1>, TexCoord_ReadIndex<u16, float, 2>),
     }),
 };
 }  // Anonymous namespace


### PR DESCRIPTION
While checking warnings in build log I found this PR from Oct 26, 2022 was not merged.

+ https://github.com/dolphin-emu/dolphin/pull/11160