### PR TITLE
AudioCommon: When ALSA is absent on Linux, default to Cubeb backend

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.cpp
+++ b/Source/Core/AudioCommon/AudioCommon.cpp
@@ -100,6 +100,8 @@ std::string GetDefaultSoundBackend()
 #elif defined __linux__
   if (AlsaSound::IsValid())
     backend = BACKEND_ALSA;
+  else
+    backend = BACKEND_CUBEB;
 #elif defined(__APPLE__) || defined(_WIN32) || defined(__OpenBSD__)
   backend = BACKEND_CUBEB;
 #endif


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/12713