### PR TITLE
Qt: fix 13524 - output resampling mode not loading correctly from ini

### DIFF
--- a/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/EnhancementsWidget.cpp
@@ -372,7 +372,8 @@ void EnhancementsWidget::LoadSettings()
   // Resampling
   const OutputResamplingMode output_resampling_mode =
       Config::Get(Config::GFX_ENHANCE_OUTPUT_RESAMPLING);
-  m_output_resampling_combo->setCurrentIndex(static_cast<int>(output_resampling_mode));
+  m_output_resampling_combo->setCurrentIndex(
+      m_output_resampling_combo->findData(static_cast<int>(output_resampling_mode)));
 
   m_output_resampling_combo->setEnabled(g_Config.backend_info.bSupportsPostProcessing);
 


### PR DESCRIPTION
+ https://github.com/dolphin-emu/dolphin/pull/12741