### PR TITLE
Set OSD color to yellow in deafult AMOLED theme

### DIFF
--- a/Source/Android/jni/AndroidCommon/AndroidTheme.cpp
+++ b/Source/Android/jni/AndroidCommon/AndroidTheme.cpp
@@ -23,8 +23,8 @@ void AndroidTheme::Set(const std::string& theme)
   }
   else
   {
-    currentFloat = F_PURPLE;
-    currentInt = &PURPLE;
+    currentFloat = F_YELLOW;
+    currentInt = &YELLOW;
   }
 }
 

--- a/Source/Android/jni/AndroidCommon/AndroidTheme.h
+++ b/Source/Android/jni/AndroidCommon/AndroidTheme.h
@@ -25,14 +25,16 @@ constexpr u32 PURPLE = 0xFFFF00FF;
 constexpr u32 RED = 0xFFFF0000;
 constexpr u32 BLUE = 0xFF00FFFF;
 constexpr u32 GREEN = 0xFF00FF00;
+constexpr u32 YELLOW = 0xFFFFFF30;
 
 constexpr float F_PURPLE[3] = {RED_MASK(PURPLE) / 255.0f, GREEN_MASK(PURPLE) / 255.0f, BLUE_MASK(PURPLE) / 255.0f};
 constexpr float F_RED[3] = {RED_MASK(RED) / 255.0f, GREEN_MASK(RED) / 255.0f, BLUE_MASK(RED) / 255.0f};
 constexpr float F_BLUE[3] = {RED_MASK(BLUE) / 255.0f, GREEN_MASK(BLUE) / 255.0f, BLUE_MASK(BLUE) / 255.0f};
 constexpr float F_GREEN[3] = {RED_MASK(GREEN) / 255.0f, GREEN_MASK(GREEN) / 255.0f, BLUE_MASK(GREEN) / 255.0f};
+constexpr float F_YELLOW[3] = {RED_MASK(YELLOW) / 255.0f, GREEN_MASK(YELLOW) / 255.0f, BLUE_MASK(YELLOW) / 255.0f};
 
-const float *currentFloat{F_PURPLE};
-const u32 *currentInt{&PURPLE};
+const float *currentFloat{F_YELLOW};
+const u32 *currentInt{&YELLOW};
 }  // Anonymous namespace
 
 void Set(const std::string& theme);

--- a/Source/Core/VideoCommon/OnScreenDisplay.h
+++ b/Source/Core/VideoCommon/OnScreenDisplay.h
@@ -30,7 +30,6 @@ constexpr u32 CYAN = 0xFF00FFFF;
 constexpr u32 GREEN = 0xFF00FF00;
 constexpr u32 RED = 0xFFFF0000;
 constexpr u32 YELLOW = 0xFFFFFF30;
-constexpr u32 FUCHSIA = 0xFFFF00FF;
 };  // namespace Color
 
 namespace Duration
@@ -40,11 +39,11 @@ constexpr u32 NORMAL = 5000;
 constexpr u32 VERY_LONG = 10000;
 };  // namespace Duration
 
-// On-screen message display (colored fuchsia by default)
-void AddMessage(std::string message, u32 ms = Duration::SHORT, u32 argb = Color::FUCHSIA,
+// On-screen message display (colored yellow by default)
+void AddMessage(std::string message, u32 ms = Duration::SHORT, u32 argb = Color::YELLOW,
                 const VideoCommon::CustomTextureData::ArraySlice::Level* icon = nullptr);
 void AddTypedMessage(MessageType type, std::string message, u32 ms = Duration::SHORT,
-                     u32 argb = Color::FUCHSIA,
+                     u32 argb = Color::YELLOW,
                      const VideoCommon::CustomTextureData::ArraySlice::Level* icon = nullptr);
 
 // Draw the current messages on the screen. Only call once per frame.


### PR DESCRIPTION
Purple is hard to read on dark backgrounds, so this changes the default OSD color back to the more readable yellow used in official Dolphin.

The code in OnScreenDisplay.h now matches official Dolphin. Color values are still overwritten by the AndroidTheme system. The colors for the OSD are defined in AndroidTheme.h and AndroidTheme.cpp, where the defaults are now set to yellow.