### PR TITLE
FatFsUtil: Generate a non-partitioned image in our folder-to-sdcard conversion.

### DIFF
--- a/Source/Core/Common/FatFsUtil.cpp
+++ b/Source/Core/Common/FatFsUtil.cpp
@@ -553,7 +553,7 @@ bool SyncSDFolderToSDImage(const std::function<bool()>& cancelled, bool determin
   }
 
   MKFS_PARM options = {};
-  options.fmt = FM_FAT32;
+  options.fmt = FM_FAT32 | FM_SFD;
   options.n_fat = 0;    // Number of FATs: automatic
   options.align = 1;    // Alignment of the data region (in sectors)
   options.n_root = 0;   // Number of root directory entries: automatic (and unused for FAT32)


### PR DESCRIPTION
- https://github.com/dolphin-emu/dolphin/pull/12834