### PR TITLE
ControllerInterface: Adjust sort priorities to ensure default keyboard-mouse device is first.

### DIFF
--- a/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
+++ b/Source/Core/InputCommon/ControllerInterface/CoreDevice.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -143,6 +144,7 @@ public:
   // A higher priority means it will be one of the first ones (smaller index), making it more
   // likely to be index 0, which is automatically set as the default device when there isn't one.
   // Every platform should have at least one device with priority >= 0.
+  static constexpr int DEFAULT_DEVICE_SORT_PRIORITY = std::numeric_limits<int>::max();
   virtual int GetSortPriority() const { return 0; }
 
   const std::vector<Input*>& Inputs() const { return m_inputs; }

--- a/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/DInput/DInputKeyboardMouse.cpp
@@ -271,7 +271,7 @@ std::string KeyboardMouse::GetSource() const
 // Give this device a higher priority to make sure it shows first
 int KeyboardMouse::GetSortPriority() const
 {
-  return 5;
+  return DEFAULT_DEVICE_SORT_PRIORITY;
 }
 
 bool KeyboardMouse::IsVirtualDevice() const

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.h
@@ -69,6 +69,7 @@ public:
 
   std::string GetName() const override;
   std::string GetSource() const override;
+  int GetSortPriority() const override;
 
 private:
   void MainThreadInitialization(void* view);

--- a/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
+++ b/Source/Core/InputCommon/ControllerInterface/Quartz/QuartzKeyboardAndMouse.mm
@@ -282,6 +282,11 @@ std::string KeyboardAndMouse::GetSource() const
   return "Quartz";
 }
 
+int KeyboardAndMouse::GetSortPriority() const
+{
+  return DEFAULT_DEVICE_SORT_PRIORITY;
+}
+
 ControlState KeyboardAndMouse::Cursor::GetState() const
 {
   return std::max(0.0, ControlState(m_axis) / (m_positive ? 1.0 : -1.0));

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.cpp
@@ -385,6 +385,11 @@ std::string KeyboardMouse::GetSource() const
   return "XInput2";
 }
 
+int KeyboardMouse::GetSortPriority() const
+{
+  return DEFAULT_DEVICE_SORT_PRIORITY;
+}
+
 KeyboardMouse::Key::Key(Display* const display, KeyCode keycode, const char* keyboard)
     : m_display(display), m_keyboard(keyboard), m_keycode(keycode)
 {

--- a/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
+++ b/Source/Core/InputCommon/ControllerInterface/Xlib/XInput2.h
@@ -119,6 +119,7 @@ public:
 
   std::string GetName() const override;
   std::string GetSource() const override;
+  int GetSortPriority() const override;
 
 private:
   Window m_window;


### PR DESCRIPTION
- https://github.com/dolphin-emu/dolphin/pull/12850