### PR TITLE
Core: Store current state in less places

### DIFF
--- a/Source/Android/jni/MainAndroid.cpp
+++ b/Source/Android/jni/MainAndroid.cpp
@@ -302,7 +302,7 @@ JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunnin
 JNIEXPORT jboolean JNICALL Java_org_dolphinemu_dolphinemu_NativeLibrary_IsRunningAndStarted(JNIEnv*,
                                                                                             jclass)
 {
-  return static_cast<jboolean>(Core::IsRunningAndStarted());
+  return static_cast<jboolean>(Core::IsRunning(Core::System::GetInstance()));
 }
 
 JNIEXPORT jboolean JNICALL

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -185,22 +185,22 @@ void SConfig::SetRunningGameMetadata(const std::string& game_id, const std::stri
   m_title_description = title_database.Describe(m_gametdb_id, language);
   NOTICE_LOG_FMT(CORE, "Active title: {}", m_title_description);
   Host_TitleChanged();
-  if (Core::IsRunning(system))
-  {
+
+  const bool is_running_or_starting = Core::IsRunningOrStarting(system);
+  if (is_running_or_starting)
     Core::UpdateTitle(system);
-  }
 
   Config::AddLayer(ConfigLoaders::GenerateGlobalGameConfigLoader(game_id, revision));
   Config::AddLayer(ConfigLoaders::GenerateLocalGameConfigLoader(game_id, revision));
 
-  if (Core::IsRunning(system))
+  if (is_running_or_starting)
     DolphinAnalytics::Instance().ReportGameStart();
 }
 
 void SConfig::OnNewTitleLoad(const Core::CPUThreadGuard& guard)
 {
   auto& system = guard.GetSystem();
-  if (!Core::IsRunning(system))
+  if (!Core::IsRunningOrStarting(system))
     return;
 
   auto& ppc_symbol_db = system.GetPPCSymbolDB();

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -135,8 +135,8 @@ void UndeclareAsHostThread();
 std::string StopMessage(bool main_thread, std::string_view message);
 
 bool IsRunning(Core::System& system);
-bool IsRunningAndStarted();  // is running and the CPU loop has been entered
-bool IsCPUThread();          // this tells us whether we are the CPU thread.
+bool IsRunningOrStarting(Core::System& system);
+bool IsCPUThread();  // this tells us whether we are the CPU thread.
 bool IsGPUThread();
 bool IsHostThread();
 

--- a/Source/Core/Core/Debugger/PPCDebugInterface.cpp
+++ b/Source/Core/Core/Debugger/PPCDebugInterface.cpp
@@ -349,7 +349,7 @@ u32 PPCDebugInterface::ReadInstruction(const Core::CPUThreadGuard& guard, u32 ad
 
 bool PPCDebugInterface::IsAlive() const
 {
-  return Core::IsRunningAndStarted();
+  return Core::IsRunning(m_system);
 }
 
 bool PPCDebugInterface::IsBreakpoint(u32 address) const

--- a/Source/Core/Core/IOS/ES/ES.cpp
+++ b/Source/Core/Core/IOS/ES/ES.cpp
@@ -112,9 +112,9 @@ ESCore::~ESCore() = default;
 ESDevice::ESDevice(EmulationKernel& ios, ESCore& core, const std::string& device_name)
     : EmulationDevice(ios, device_name), m_core(core)
 {
-  if (Core::IsRunningAndStarted())
+  auto& system = ios.GetSystem();
+  if (Core::IsRunning(system))
   {
-    auto& system = ios.GetSystem();
     auto& core_timing = system.GetCoreTiming();
     core_timing.RemoveEvent(s_finish_init_event);
     core_timing.ScheduleEvent(GetESBootTicks(ios.GetVersion()), s_finish_init_event);
@@ -446,7 +446,7 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
     }
 
     const u64 required_ios = tmd.GetIOSId();
-    if (!Core::IsRunningAndStarted())
+    if (!Core::IsRunning(system))
       return LaunchTitle(required_ios, HangPPC::Yes);
     core_timing.RemoveEvent(s_reload_ios_for_ppc_launch_event);
     core_timing.ScheduleEvent(ticks, s_reload_ios_for_ppc_launch_event, required_ios);
@@ -475,7 +475,7 @@ bool ESDevice::LaunchPPCTitle(u64 title_id)
     return false;
 
   m_pending_ppc_boot_content_path = m_core.GetContentPath(tmd.GetTitleId(), content);
-  if (!Core::IsRunningAndStarted())
+  if (!Core::IsRunning(system))
     return BootstrapPPC();
 
   INFO_LOG_FMT(ACHIEVEMENTS,

--- a/Source/Core/Core/IOS/IOS.cpp
+++ b/Source/Core/Core/IOS/IOS.cpp
@@ -518,7 +518,7 @@ bool EmulationKernel::BootIOS(const u64 ios_title_id, HangPPC hang_ppc,
   if (hang_ppc == HangPPC::Yes)
     ResetAndPausePPC(m_system);
 
-  if (Core::IsRunningAndStarted())
+  if (Core::IsRunning(m_system))
   {
     m_system.GetCoreTiming().ScheduleEvent(GetIOSBootTicks(GetVersion()), s_event_finish_ios_boot,
                                            ios_title_id);

--- a/Source/Core/Core/Movie.cpp
+++ b/Source/Core/Core/Movie.cpp
@@ -536,7 +536,7 @@ bool MovieManager::BeginRecordingInput(const ControllerTypeArray& controllers,
         m_bongos |= (1 << i);
     }
 
-    if (Core::IsRunningAndStarted())
+    if (Core::IsRunning(m_system))
     {
       const std::string save_path = File::GetUserPath(D_STATESAVES_IDX) + "dtm.sav";
       if (File::Exists(save_path))
@@ -551,7 +551,7 @@ bool MovieManager::BeginRecordingInput(const ControllerTypeArray& controllers,
     }
 
     // Wiimotes cause desync issues if they're not reset before launching the game
-    if (!Core::IsRunningAndStarted())
+    if (!Core::IsRunning(m_system))
     {
       // This will also reset the Wiimotes for GameCube games, but that shouldn't do anything
       Wiimote::ResetAllWiimotes();
@@ -1339,7 +1339,7 @@ void MovieManager::EndPlayInput(bool cont)
   {
     // We can be called by EmuThread during boot (CPU::State::PowerDown)
     auto& cpu = m_system.GetCPU();
-    const bool was_running = Core::IsRunningAndStarted() && !cpu.IsStepping();
+    const bool was_running = Core::IsRunning(m_system) && !cpu.IsStepping();
     if (was_running && Config::Get(Config::MAIN_MOVIE_PAUSE_MOVIE))
       cpu.Break();
     m_rerecords = 0;

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -854,7 +854,7 @@ static void LoadFileStateData(const std::string& filename, std::vector<u8>& ret_
 
 void LoadAs(Core::System& system, const std::string& filename)
 {
-  if (!Core::IsRunning(system))
+  if (!Core::IsRunningOrStarting(system))
     return;
 
   if (NetPlay::IsNetPlayRunning())

--- a/Source/Core/DolphinQt/HotkeyScheduler.cpp
+++ b/Source/Core/DolphinQt/HotkeyScheduler.cpp
@@ -159,7 +159,8 @@ void HotkeyScheduler::Run()
     if (!HotkeyManagerEmu::IsEnabled())
       continue;
 
-    if (Core::GetState(Core::System::GetInstance()) != Core::State::Stopping)
+    Core::System& system = Core::System::GetInstance();
+    if (Core::GetState(system) != Core::State::Stopping)
     {
       // Obey window focus (config permitting) before checking hotkeys.
       Core::UpdateInputGate(Config::Get(Config::MAIN_FOCUSED_HOTKEYS));
@@ -187,7 +188,7 @@ void HotkeyScheduler::Run()
       if (IsHotkey(HK_EXIT))
         emit ExitHotkey();
 
-      if (!Core::IsRunningAndStarted())
+      if (!Core::IsRunning(system))
       {
         // Only check for Play Recording hotkey when no game is running
         if (IsHotkey(HK_PLAY_RECORDING))

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1889,7 +1889,7 @@ void MainWindow::OnStartRecording()
 {
   auto& system = Core::System::GetInstance();
   auto& movie = system.GetMovie();
-  if ((!Core::IsRunningAndStarted() && Core::IsRunning(system)) || movie.IsRecordingInput() ||
+  if (Core::GetState(system) == Core::State::Starting || movie.IsRecordingInput() ||
       movie.IsPlayingInput())
   {
     return;

--- a/Source/Core/DolphinQt/RenderWidget.cpp
+++ b/Source/Core/DolphinQt/RenderWidget.cpp
@@ -513,7 +513,7 @@ bool RenderWidget::event(QEvent* event)
 
 void RenderWidget::PassEventToPresenter(const QEvent* event)
 {
-  if (!Core::IsRunningAndStarted())
+  if (!Core::IsRunning(Core::System::GetInstance()))
     return;
 
   switch (event->type())

--- a/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
+++ b/Source/Core/InputCommon/ControllerInterface/Touch/ButtonManager.cpp
@@ -22,6 +22,7 @@
 #include "Core/HW/WiimoteEmu/Extension/Classic.h"
 #include "Core/HW/WiimoteEmu/Extension/Nunchuk.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
+#include "Core/System.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/StickGate.h"
@@ -712,7 +713,7 @@ float GetAxisValue(int pad_id, ButtonType axis)
 double GetInputRadiusAtAngle(int pad_id, ButtonType stick, double angle)
 {
   // To avoid a crash, don't access controllers before they've been initialized by the boot process
-  if (!Core::IsRunningAndStarted())
+  if (!Core::IsRunning(Core::System::GetInstance()))
     return 0;
 
   ControllerEmu::ControlGroup* group;

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -66,7 +66,7 @@ void VideoConfig::Refresh()
     CPUThreadConfigCallback::AddConfigChangedCallback([]() {
       auto& system = Core::System::GetInstance();
 
-      const bool lock_gpu_thread = Core::IsRunningAndStarted();
+      const bool lock_gpu_thread = Core::IsRunning(system);
       if (lock_gpu_thread)
         system.GetFifo().PauseAndLock(true, false);
 


### PR DESCRIPTION
Based on:
- https://github.com/dolphin-emu/dolphin/pull/12828

The commit - https://github.com/dolphin-emu/dolphin/pull/12828/commits/72cf2bdb87f09deff22e1085de3290126aa4ad05 broke dual core and caused SYSCONF settings getting cleared where they shouldn´t be. It was then reverted by the following PR´s.

- https://github.com/dolphin-emu/dolphin/pull/12886
- https://github.com/dolphin-emu/dolphin/pull/12893

I skipped the reverts and kept only the changes from https://github.com/dolphin-emu/dolphin/pull/12828/commits/962230f91e06a60b2395de6f0974fdd213854d4c. I also fixed a state handling in MMJR2 specific ButtonManager.