### PR TITLE
Android: Add centered text option for HeaderSettings

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/HeaderSetting.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/HeaderSetting.java
@@ -8,15 +8,35 @@ import org.dolphinemu.dolphinemu.features.settings.model.AbstractSetting;
 
 public class HeaderSetting extends SettingsItem
 {
+  public enum Style
+  {
+    NORMAL,
+    CENTERED
+  }
+
+  private final Style style;
+
   public HeaderSetting(Context context, int titleId, int descriptionId)
   {
     super(context, titleId, descriptionId);
+    this.style = Style.NORMAL;
+  }
+
+  private HeaderSetting(Context context, int titleId, int descriptionId, Style style)
+  {
+    super(context, titleId, descriptionId);
+    this.style = style;
+  }
+
+   public static HeaderSetting centered(Context context, int titleId, int descriptionId)
+  {
+    return new HeaderSetting(context, titleId, descriptionId, Style.CENTERED);
   }
 
   @Override
   public int getType()
   {
-    return SettingsItem.TYPE_HEADER;
+    return (style == Style.CENTERED) ? TYPE_HEADER_CENTERED : TYPE_HEADER;
   }
 
   @Override

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/model/view/SettingsItem.java
@@ -30,6 +30,7 @@ public abstract class SettingsItem
   public static final int TYPE_STRING = 11;
   public static final int TYPE_HYPERLINK_HEADER = 12;
   public static final int TYPE_SLIDER_SELECTOR = 13;
+  public static final int TYPE_HEADER_CENTERED = 14;
 
   private final CharSequence mName;
   private final CharSequence mDescription;

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/features/settings/ui/SettingsAdapter.java
@@ -97,6 +97,10 @@ public final class SettingsAdapter extends RecyclerView.Adapter<SettingViewHolde
         view = inflater.inflate(R.layout.list_item_header, parent, false);
         return new HeaderViewHolder(view, this);
 
+      case SettingsItem.TYPE_HEADER_CENTERED:
+        view = inflater.inflate(R.layout.list_item_header_centered, parent, false);
+        return new HeaderViewHolder(view, this);
+
       case SettingsItem.TYPE_CHECKBOX:
         return new CheckBoxSettingViewHolder(ListItemSettingCheckboxBinding.inflate(inflater),
           this);

--- a/Source/Android/app/src/main/res/layout/list_item_header_centered.xml
+++ b/Source/Android/app/src/main/res/layout/list_item_header_centered.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:focusable="true"
+    android:layout_height="48dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/text_header_name"
+        tools:text="CPU Settings"
+        android:layout_marginBottom="@dimen/spacing_small"
+        android:textColor="?attr/colorAccent"
+        android:textStyle="bold"
+        android:layout_gravity="center"
+        android:gravity="center"/>
+
+</FrameLayout>


### PR DESCRIPTION
Add support for centered header text in settings lists using HeaderSetting.centered() method while keeping existing headers unchanged. This is just a small tweak I wanted to do while learning Android development. I wonder why everything in Android has to be so overcomplicated.